### PR TITLE
Revert "Disable transaction test cases temporarily"

### DIFF
--- a/mysql-ballerina/src/mysql/tests/pool/connection-pool-test.bal
+++ b/mysql-ballerina/src/mysql/tests/pool/connection-pool-test.bal
@@ -469,7 +469,7 @@ function testGlobalConnectionPoolConcurrentHelper2(string database) returns @tai
     return returnArray;
 }
 
-function getCombinedReturnValue([stream<record{}, error>, stream<record{}, error>]|error queryResult) returns
+isolated function getCombinedReturnValue([stream<record{}, error>, stream<record{}, error>]|error queryResult) returns
  (int|error)[]|error {
     if (queryResult is error) {
         return queryResult;
@@ -484,7 +484,7 @@ function getCombinedReturnValue([stream<record{}, error>, stream<record{}, error
     }
 }
 
-function getIntVariableValue(stream<record{}, error> queryResult) returns int|error {
+isolated function getIntVariableValue(stream<record{}, error> queryResult) returns int|error {
     int count = -1;
     record {|record {} value;|}? data = check queryResult.next();
     if (data is record {|record {} value;|}) {
@@ -543,7 +543,7 @@ function drainGlobalPool(string database) {
     validateConnectionTimeoutError(returnArray[10]);
 }
 
-function getReturnValue(stream<record{}, error> queryResult) returns int|error {
+isolated function getReturnValue(stream<record{}, error> queryResult) returns int|error {
     int count = -1;
     record {|record {} value;|}? data = check queryResult.next();
     if (data is record {|record {} value;|}) {

--- a/mysql-ballerina/src/mysql/tests/transaction/local-transaction-test.bal
+++ b/mysql-ballerina/src/mysql/tests/transaction/local-transaction-test.bal
@@ -280,7 +280,7 @@ function testTransactionErrorPanicAndTrap() {
     test:assertEquals(count, 1);
 }
 
-function testTransactionErrorPanicAndTrapHelper(int i) {
+isolated function testTransactionErrorPanicAndTrapHelper(int i) {
     if (i == 0) {
         error err = error("error");
         panic err;
@@ -390,7 +390,7 @@ function testLocalTransactionFailedHelper(string status,Client dbClient) returns
     return a;
 }
 
-function getError(string message) returns error? {
+isolated function getError(string message) returns error? {
     return error(message);
 }
 

--- a/mysql-ballerina/src/mysql/tests/transaction/local-transaction-test.bal
+++ b/mysql-ballerina/src/mysql/tests/transaction/local-transaction-test.bal
@@ -14,439 +14,436 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// todo Disabling due to https://github.com/ballerina-platform/ballerina-lang/issues/26972
-// Since its a compiler issue this needs to be commented out
+import ballerina/lang.'transaction as transactions;
+import ballerina/io;
+import ballerina/sql;
+import ballerina/test;
 
-// import ballerina/lang.'transaction as transactions;
-// import ballerina/io;
-// import ballerina/sql;
-// import ballerina/test;
+string localTransactionDB = "LOCAL_TRANSACTION";
 
-// string localTransactionDB = "LOCAL_TRANSACTION";
+type TransactionResultCount record {
+    int COUNTVAL;
+};
 
-// type TransactionResultCount record {
-//     int COUNTVAL;
-// };
+@test:Config {
+    groups: ["transaction", "local-transaction"]
+}
+function testLocalTransaction() {
+    Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
+    int retryVal = -1;
+    boolean committedBlockExecuted = false;
+    transactions:Info transInfo;
+    retry(1) transaction {
+        var res = dbClient->execute("Insert into Customers (firstName,lastName,registrationID,creditLimit,country) " +
+                                "values ('James', 'Clerk', 200, 5000.75, 'USA')");
+        res = dbClient->execute("Insert into Customers (firstName,lastName,registrationID,creditLimit,country) " +
+                                "values ('James', 'Clerk', 200, 5000.75, 'USA')");
+        transInfo = transactions:info();
+        var commitResult = commit;
+        if(commitResult is ()){
+            committedBlockExecuted = true;
+        }
+    }
+    retryVal = transInfo.retryNumber;
+    //check whether update action is performed
+    int count = getCount(dbClient, "200");
+    checkpanic dbClient.close();
 
-// @test:Config {
-//     groups: ["transaction", "local-transaction"]
-// }
-// function testLocalTransaction() {
-//     Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
-//     int retryVal = -1;
-//     boolean committedBlockExecuted = false;
-//     transactions:Info transInfo;
-//     retry(1) transaction {
-//         var res = dbClient->execute("Insert into Customers (firstName,lastName,registrationID,creditLimit,country) " +
-//                                 "values ('James', 'Clerk', 200, 5000.75, 'USA')");
-//         res = dbClient->execute("Insert into Customers (firstName,lastName,registrationID,creditLimit,country) " +
-//                                 "values ('James', 'Clerk', 200, 5000.75, 'USA')");
-//         transInfo = transactions:info();
-//         var commitResult = commit;
-//         if(commitResult is ()){
-//             committedBlockExecuted = true;
-//         }
-//     }
-//     retryVal = transInfo.retryNumber;
-//     //check whether update action is performed
-//     int count = getCount(dbClient, "200");
-//     checkpanic dbClient.close();
+    test:assertEquals(retryVal, 0);
+    test:assertEquals(count, 2);
+    test:assertEquals(committedBlockExecuted, true);
+}
 
-//     test:assertEquals(retryVal, 0);
-//     test:assertEquals(count, 2);
-//     test:assertEquals(committedBlockExecuted, true);
-// }
+boolean stmtAfterFailureExecutedRWC = false;
+int retryValRWC = -1;
+@test:Config {
+    groups: ["transaction", "local-transaction"],
+    dependsOn: ["testLocalTransaction"]
+}
+function testTransactionRollbackWithCheck() {
+    Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
+    var result = testTransactionRollbackWithCheckHelper(dbClient);
+    int count = getCount(dbClient, "210");
+    checkpanic dbClient.close();
 
-// boolean stmtAfterFailureExecutedRWC = false;
-// int retryValRWC = -1;
-// @test:Config {
-//     groups: ["transaction", "local-transaction"],
-//     dependsOn: ["testLocalTransaction"]
-// }
-// function testTransactionRollbackWithCheck() {
-//     Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
-//     var result = testTransactionRollbackWithCheckHelper(dbClient);
-//     int count = getCount(dbClient, "210");
-//     checkpanic dbClient.close();
+    test:assertEquals(retryValRWC, 1);
+    test:assertEquals(count, 0);
+    test:assertEquals(stmtAfterFailureExecutedRWC, false);
+}
 
-//     test:assertEquals(retryValRWC, 1);
-//     test:assertEquals(count, 0);
-//     test:assertEquals(stmtAfterFailureExecutedRWC, false);
-// }
+function testTransactionRollbackWithCheckHelper(Client dbClient) returns error?{
+    transactions:Info transInfo;
+    retry(1) transaction {
+        transInfo = transactions:info();
+        retryValRWC = transInfo.retryNumber;
+        var e1 = check dbClient->execute("Insert into Customers (firstName,lastName,registrationID," +
+                "creditLimit,country) values ('James', 'Clerk', 210, 5000.75, 'USA')");
+        var e2 = check dbClient->execute("Insert into Customers2 (firstName,lastName,registrationID," +
+                    "creditLimit,country) values ('James', 'Clerk', 210, 5000.75, 'USA')");
+        stmtAfterFailureExecutedRWC  = true;
+        check commit;
+    }
+}
 
-// function testTransactionRollbackWithCheckHelper(Client dbClient) returns error?{
-//     transactions:Info transInfo;
-//     retry(1) transaction {
-//         transInfo = transactions:info();
-//         retryValRWC = transInfo.retryNumber;
-//         var e1 = check dbClient->execute("Insert into Customers (firstName,lastName,registrationID," +
-//                 "creditLimit,country) values ('James', 'Clerk', 210, 5000.75, 'USA')");
-//         var e2 = check dbClient->execute("Insert into Customers2 (firstName,lastName,registrationID," +
-//                     "creditLimit,country) values ('James', 'Clerk', 210, 5000.75, 'USA')");
-//         stmtAfterFailureExecutedRWC  = true;
-//         check commit;
-//     }
-// }
+@test:Config {
+    groups: ["transaction", "local-transaction"],
+    dependsOn: ["testTransactionRollbackWithCheck"]
+}
+function testTransactionRollbackWithRollback() {
+    Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
+    int retryVal = -1;
+    boolean stmtAfterFailureExecuted = false;
+    transactions:Info transInfo;
+    retry(1) transaction {
+        transInfo = transactions:info();
+        var e1 = dbClient->execute("Insert into Customers (firstName,lastName,registrationID," +
+                "creditLimit,country) values ('James', 'Clerk', 211, 5000.75, 'USA')");
+        if (e1 is error){
+            rollback;
+        } else {
+            var e2 = dbClient->execute("Insert into Customers2 (firstName,lastName,registrationID," +
+                        "creditLimit,country) values ('James', 'Clerk', 211, 5000.75, 'USA')");
+            if (e2 is error){
+                rollback;
+                stmtAfterFailureExecuted  = true;
+            } else {
+                checkpanic commit;
+            }
+        }
+    }
+    retryVal = transInfo.retryNumber;
+    int count = getCount(dbClient, "211");
+    checkpanic dbClient.close();
 
-// @test:Config {
-//     groups: ["transaction", "local-transaction"],
-//     dependsOn: ["testTransactionRollbackWithCheck"]
-// }
-// function testTransactionRollbackWithRollback() {
-//     Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
-//     int retryVal = -1;
-//     boolean stmtAfterFailureExecuted = false;
-//     transactions:Info transInfo;
-//     retry(1) transaction {
-//         transInfo = transactions:info();
-//         var e1 = dbClient->execute("Insert into Customers (firstName,lastName,registrationID," +
-//                 "creditLimit,country) values ('James', 'Clerk', 211, 5000.75, 'USA')");
-//         if (e1 is error){
-//             rollback;
-//         } else {
-//             var e2 = dbClient->execute("Insert into Customers2 (firstName,lastName,registrationID," +
-//                         "creditLimit,country) values ('James', 'Clerk', 211, 5000.75, 'USA')");
-//             if (e2 is error){
-//                 rollback;
-//                 stmtAfterFailureExecuted  = true;
-//             } else {
-//                 checkpanic commit;
-//             }
-//         }
-//     }
-//     retryVal = transInfo.retryNumber;
-//     int count = getCount(dbClient, "211");
-//     checkpanic dbClient.close();
+    test:assertEquals(retryVal, 0);
+    test:assertEquals(count, 0);
+    test:assertEquals(stmtAfterFailureExecuted, true);
 
-//     test:assertEquals(retryVal, 0);
-//     test:assertEquals(count, 0);
-//     test:assertEquals(stmtAfterFailureExecuted, true);
+}
 
-// }
+@test:Config {
+    groups: ["transaction", "local-transaction"],
+    dependsOn: ["testTransactionRollbackWithRollback"]
+}
+function testLocalTransactionUpdateWithGeneratedKeys() {
+    Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
+    int returnVal = 0;
+    transactions:Info transInfo;
+    retry (1) transaction {
+        transInfo = transactions:info();
+        var e1 = checkpanic dbClient->execute("Insert into Customers " +
+         "(firstName,lastName,registrationID,creditLimit,country) values ('James', 'Clerk', 615, 5000.75, 'USA')");
+        var e2 =  checkpanic dbClient->execute("Insert into Customers " +
+        "(firstName,lastName,registrationID,creditLimit,country) values ('James', 'Clerk', 615, 5000.75, 'USA')");
+        checkpanic commit;
+    }
+    returnVal = transInfo.retryNumber;
+    //Check whether the update action is performed.
+    int count = getCount(dbClient, "615");
+    checkpanic dbClient.close();
 
-// @test:Config {
-//     groups: ["transaction", "local-transaction"],
-//     dependsOn: ["testTransactionRollbackWithRollback"]
-// }
-// function testLocalTransactionUpdateWithGeneratedKeys() {
-//     Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
-//     int returnVal = 0;
-//     transactions:Info transInfo;
-//     retry (1) transaction {
-//         transInfo = transactions:info();
-//         var e1 = checkpanic dbClient->execute("Insert into Customers " +
-//          "(firstName,lastName,registrationID,creditLimit,country) values ('James', 'Clerk', 615, 5000.75, 'USA')");
-//         var e2 =  checkpanic dbClient->execute("Insert into Customers " +
-//         "(firstName,lastName,registrationID,creditLimit,country) values ('James', 'Clerk', 615, 5000.75, 'USA')");
-//         checkpanic commit;
-//     }
-//     returnVal = transInfo.retryNumber;
-//     //Check whether the update action is performed.
-//     int count = getCount(dbClient, "615");
-//     checkpanic dbClient.close();
+    test:assertEquals(returnVal, 0);
+    test:assertEquals(count, 2);
+}
 
-//     test:assertEquals(returnVal, 0);
-//     test:assertEquals(count, 2);
-// }
+int returnValRGK = 0;
+@test:Config {
+    groups: ["transaction", "local-transaction"],
+    dependsOn: ["testLocalTransactionUpdateWithGeneratedKeys"]
+}
+function testLocalTransactionRollbackWithGeneratedKeys() {
+    Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
+    var result = testLocalTransactionRollbackWithGeneratedKeysHelper(dbClient);
+    //check whether update action is performed
+    int count = getCount(dbClient, "615");
+    checkpanic dbClient.close();
+    test:assertEquals(returnValRGK, 1);
+    test:assertEquals(count, 2);
+}
 
-// int returnValRGK = 0;
-// @test:Config {
-//     groups: ["transaction", "local-transaction"],
-//     dependsOn: ["testLocalTransactionUpdateWithGeneratedKeys"]
-// }
-// function testLocalTransactionRollbackWithGeneratedKeys() {
-//     Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
-//     var result = testLocalTransactionRollbackWithGeneratedKeysHelper(dbClient);
-//     //check whether update action is performed
-//     int count = getCount(dbClient, "615");
-//     checkpanic dbClient.close();
-//     test:assertEquals(returnValRGK, 1);
-//     test:assertEquals(count, 2);
-// }
+function testLocalTransactionRollbackWithGeneratedKeysHelper(Client dbClient) returns error? {
+    transactions:Info transInfo;
+    retry(1) transaction {
+        transInfo = transactions:info();
+        returnValRGK = transInfo.retryNumber;
+        var e1 = check dbClient->execute("Insert into Customers " +
+         "(firstName,lastName,registrationID,creditLimit,country) values ('James', 'Clerk', 615, 5000.75, 'USA')");
+        var e2 = check dbClient->execute("Insert into Customers2 " +
+        "(firstName,lastName,registrationID,creditLimit,country) values ('James', 'Clerk', 615, 5000.75, 'USA')");
+        check commit;
+    }
+}
 
-// function testLocalTransactionRollbackWithGeneratedKeysHelper(Client dbClient) returns error? {
-//     transactions:Info transInfo;
-//     retry(1) transaction {
-//         transInfo = transactions:info();
-//         returnValRGK = transInfo.retryNumber;
-//         var e1 = check dbClient->execute("Insert into Customers " +
-//          "(firstName,lastName,registrationID,creditLimit,country) values ('James', 'Clerk', 615, 5000.75, 'USA')");
-//         var e2 = check dbClient->execute("Insert into Customers2 " +
-//         "(firstName,lastName,registrationID,creditLimit,country) values ('James', 'Clerk', 615, 5000.75, 'USA')");
-//         check commit;
-//     }
-// }
+@test:Config {
+    groups: ["transaction", "local-transaction"],
+    dependsOn: ["testLocalTransactionRollbackWithGeneratedKeys"]
+}
+function testTransactionAbort() {
+    Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
+    transactions:Info transInfo;
 
-// @test:Config {
-//     groups: ["transaction", "local-transaction"],
-//     dependsOn: ["testLocalTransactionRollbackWithGeneratedKeys"]
-// }
-// function testTransactionAbort() {
-//     Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
-//     transactions:Info transInfo;
+    int abortVal = 0;
+    var abortFunc = function(transactions:Info? info, error? cause, boolean willTry) {
+        abortVal = -1;
+    };
 
-//     int abortVal = 0;
-//     var abortFunc = function(transactions:Info? info, error? cause, boolean willTry) {
-//         abortVal = -1;
-//     };
+    retry(1) transaction {
+        transInfo = transactions:info();
+        transactions:onRollback(abortFunc);
+        var e1 = dbClient->execute("Insert into Customers " +
+         "(firstName,lastName,registrationID,creditLimit,country) values ('James', 'Clerk', 220, 5000.75, 'USA')");
+        var e2 =  dbClient->execute("Insert into Customers " +
+        "(firstName,lastName,registrationID,creditLimit,country) values ('James', 'Clerk', 220, 5000.75, 'USA')");
+        int i = 0;
+        if (i == 0) {
+            rollback;
+        } else {
+            checkpanic commit;
+        }
+    }
+    int returnVal = transInfo.retryNumber;
+    //Check whether the update action is performed.
+    int count = getCount(dbClient, "220");
+    checkpanic dbClient.close();
 
-//     retry(1) transaction {
-//         transInfo = transactions:info();
-//         transactions:onRollback(abortFunc);
-//         var e1 = dbClient->execute("Insert into Customers " +
-//          "(firstName,lastName,registrationID,creditLimit,country) values ('James', 'Clerk', 220, 5000.75, 'USA')");
-//         var e2 =  dbClient->execute("Insert into Customers " +
-//         "(firstName,lastName,registrationID,creditLimit,country) values ('James', 'Clerk', 220, 5000.75, 'USA')");
-//         int i = 0;
-//         if (i == 0) {
-//             rollback;
-//         } else {
-//             checkpanic commit;
-//         }
-//     }
-//     int returnVal = transInfo.retryNumber;
-//     //Check whether the update action is performed.
-//     int count = getCount(dbClient, "220");
-//     checkpanic dbClient.close();
+    test:assertEquals(returnVal, 0);
+    test:assertEquals(abortVal, -1);
+    test:assertEquals(count, 0);
+}
 
-//     test:assertEquals(returnVal, 0);
-//     test:assertEquals(abortVal, -1);
-//     test:assertEquals(count, 0);
-// }
+int testTransactionErrorPanicRetVal = 0;
+@test:Config {
+    enable: false,
+    groups: ["transaction", "local-transaction"]
+}
+function testTransactionErrorPanic() {
+    Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
+    int returnVal = 0;
+    int catchValue = 0;
+    var ret = trap testTransactionErrorPanicHelper(dbClient);
+    io:println(ret);
+    if (ret is error) {
+        catchValue = -1;
+    }
+    //Check whether the update action is performed.
+    int count = getCount(dbClient, "260");
+    checkpanic dbClient.close();
+    test:assertEquals(testTransactionErrorPanicRetVal, 1);
+    test:assertEquals(catchValue, -1);
+    test:assertEquals(count, 0);
+}
 
-// int testTransactionErrorPanicRetVal = 0;
-// @test:Config {
-//     enable: false,
-//     groups: ["transaction", "local-transaction"]
-// }
-// function testTransactionErrorPanic() {
-//     Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
-//     int returnVal = 0;
-//     int catchValue = 0;
-//     var ret = trap testTransactionErrorPanicHelper(dbClient);
-//     io:println(ret);
-//     if (ret is error) {
-//         catchValue = -1;
-//     }
-//     //Check whether the update action is performed.
-//     int count = getCount(dbClient, "260");
-//     checkpanic dbClient.close();
-//     test:assertEquals(testTransactionErrorPanicRetVal, 1);
-//     test:assertEquals(catchValue, -1);
-//     test:assertEquals(count, 0);
-// }
+function testTransactionErrorPanicHelper(Client dbClient) {
+    int returnVal = 0;
+    transactions:Info transInfo;
+    retry(1) transaction {
+        transInfo = transactions:info();
+        var e1 = dbClient->execute("Insert into Customers (firstName,lastName," +
+                              "registrationID,creditLimit,country) values ('James', 'Clerk', 260, 5000.75, 'USA')");
+        int i = 0;
+        if (i == 0) {
+            error e = error("error");
+            panic e;
+        } else {
+            var r = commit;
+        }
+    }
+    io:println("exec");
+    testTransactionErrorPanicRetVal = transInfo.retryNumber;
+}
 
-// function testTransactionErrorPanicHelper(Client dbClient) {
-//     int returnVal = 0;
-//     transactions:Info transInfo;
-//     retry(1) transaction {
-//         transInfo = transactions:info();
-//         var e1 = dbClient->execute("Insert into Customers (firstName,lastName," +
-//                               "registrationID,creditLimit,country) values ('James', 'Clerk', 260, 5000.75, 'USA')");
-//         int i = 0;
-//         if (i == 0) {
-//             error e = error("error");
-//             panic e;
-//         } else {
-//             var r = commit;
-//         }
-//     }
-//     io:println("exec");
-//     testTransactionErrorPanicRetVal = transInfo.retryNumber;
-// }
+@test:Config {
+    groups: ["transaction", "local-transaction"],
+    dependsOn: ["testTransactionAbort"]
+}
+function testTransactionErrorPanicAndTrap() {
+    Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
 
-// @test:Config {
-//     groups: ["transaction", "local-transaction"],
-//     dependsOn: ["testTransactionAbort"]
-// }
-// function testTransactionErrorPanicAndTrap() {
-//     Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
+    int catchValue = 0;
+    transactions:Info transInfo;
+    retry (1) transaction {
+        transInfo = transactions:info();
+        var e1 = dbClient->execute("Insert into Customers (firstName,lastName,registrationID," +
+                 "creditLimit,country) values ('James', 'Clerk', 250, 5000.75, 'USA')");
+        var ret = trap testTransactionErrorPanicAndTrapHelper(0);
+        if (ret is error) {
+            catchValue = -1;
+        }
+        checkpanic commit;
+    }
+    int returnVal = transInfo.retryNumber;
+    //Check whether the update action is performed.
+    int count = getCount(dbClient, "250");
+    checkpanic dbClient.close();
+    test:assertEquals(returnVal, 0);
+    test:assertEquals(catchValue, -1);
+    test:assertEquals(count, 1);
+}
 
-//     int catchValue = 0;
-//     transactions:Info transInfo;
-//     retry (1) transaction {
-//         transInfo = transactions:info();
-//         var e1 = dbClient->execute("Insert into Customers (firstName,lastName,registrationID," +
-//                  "creditLimit,country) values ('James', 'Clerk', 250, 5000.75, 'USA')");
-//         var ret = trap testTransactionErrorPanicAndTrapHelper(0);
-//         if (ret is error) {
-//             catchValue = -1;
-//         }
-//         checkpanic commit;
-//     }
-//     int returnVal = transInfo.retryNumber;
-//     //Check whether the update action is performed.
-//     int count = getCount(dbClient, "250");
-//     checkpanic dbClient.close();
-//     test:assertEquals(returnVal, 0);
-//     test:assertEquals(catchValue, -1);
-//     test:assertEquals(count, 1);
-// }
+function testTransactionErrorPanicAndTrapHelper(int i) {
+    if (i == 0) {
+        error err = error("error");
+        panic err;
+    }
+}
 
-// function testTransactionErrorPanicAndTrapHelper(int i) {
-//     if (i == 0) {
-//         error err = error("error");
-//         panic err;
-//     }
-// }
+@test:Config {
+    groups: ["transaction", "local-transaction"],
+    dependsOn: ["testTransactionErrorPanicAndTrap"]
+}
+function testTwoTransactions() {
+    Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
 
-// @test:Config {
-//     groups: ["transaction", "local-transaction"],
-//     dependsOn: ["testTransactionErrorPanicAndTrap"]
-// }
-// function testTwoTransactions() {
-//     Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
+     transactions:Info transInfo1;
+     transactions:Info transInfo2;
+     retry (1) transaction {
+         transInfo1 = transactions:info();
+         var e1 = checkpanic dbClient->execute("Insert into Customers (firstName,lastName,registrationID,creditLimit,country) " +
+                             "values ('James', 'Clerk', 400, 5000.75, 'USA')");
+         var e2 = checkpanic dbClient->execute("Insert into Customers (firstName,lastName,registrationID,creditLimit,country) " +
+                             "values ('James', 'Clerk', 400, 5000.75, 'USA')");
+         checkpanic commit;
+     }
+     int returnVal1 = transInfo1.retryNumber;
 
-//      transactions:Info transInfo1;
-//      transactions:Info transInfo2;
-//      retry (1) transaction {
-//          transInfo1 = transactions:info();
-//          var e1 = checkpanic dbClient->execute("Insert into Customers (firstName,lastName,registrationID,creditLimit,country) " +
-//                              "values ('James', 'Clerk', 400, 5000.75, 'USA')");
-//          var e2 = checkpanic dbClient->execute("Insert into Customers (firstName,lastName,registrationID,creditLimit,country) " +
-//                              "values ('James', 'Clerk', 400, 5000.75, 'USA')");
-//          checkpanic commit;
-//      }
-//      int returnVal1 = transInfo1.retryNumber;
+     retry(1) transaction {
+         transInfo2 = transactions:info();
+         var e1 = dbClient->execute("Insert into Customers (firstName,lastName,registrationID,creditLimit,country) " +
+                             "values ('James', 'Clerk', 400, 5000.75, 'USA')");
+         var e2 = dbClient->execute("Insert into Customers (firstName,lastName,registrationID,creditLimit,country) " +
+                             "values ('James', 'Clerk', 400, 5000.75, 'USA')");
+         checkpanic commit;
+     }
+     int returnVal2 = transInfo2.retryNumber;
 
-//      retry(1) transaction {
-//          transInfo2 = transactions:info();
-//          var e1 = dbClient->execute("Insert into Customers (firstName,lastName,registrationID,creditLimit,country) " +
-//                              "values ('James', 'Clerk', 400, 5000.75, 'USA')");
-//          var e2 = dbClient->execute("Insert into Customers (firstName,lastName,registrationID,creditLimit,country) " +
-//                              "values ('James', 'Clerk', 400, 5000.75, 'USA')");
-//          checkpanic commit;
-//      }
-//      int returnVal2 = transInfo2.retryNumber;
+     //Check whether the update action is performed.
+     int count = getCount(dbClient, "400");
+     checkpanic dbClient.close();
+    test:assertEquals(returnVal1, 0);
+    test:assertEquals(returnVal2, 0);
+    test:assertEquals(count, 4);
+ }
 
-//      //Check whether the update action is performed.
-//      int count = getCount(dbClient, "400");
-//      checkpanic dbClient.close();
-//     test:assertEquals(returnVal1, 0);
-//     test:assertEquals(returnVal2, 0);
-//     test:assertEquals(count, 4);
-//  }
+@test:Config {
+    groups: ["transaction", "local-transaction"],
+    dependsOn: ["testTwoTransactions"]
+}
+function testTransactionWithoutHandlers() {
+    Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
+    transaction {
+        var e1 = checkpanic dbClient->execute("Insert into Customers (firstName,lastName,registrationID,creditLimit,country) " +
+                            "values ('James', 'Clerk', 350, 5000.75, 'USA')");
+        var e2 = checkpanic dbClient->execute("Insert into Customers (firstName,lastName,registrationID,creditLimit,country) " +
+                            "values ('James', 'Clerk', 350, 5000.75, 'USA')");
+        checkpanic commit;
+    }
+    //Check whether the update action is performed.
+    int count = getCount(dbClient, "350");
+    checkpanic dbClient.close();
+    test:assertEquals(count, 2);
+}
 
-// @test:Config {
-//     groups: ["transaction", "local-transaction"],
-//     dependsOn: ["testTwoTransactions"]
-// }
-// function testTransactionWithoutHandlers() {
-//     Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
-//     transaction {
-//         var e1 = checkpanic dbClient->execute("Insert into Customers (firstName,lastName,registrationID,creditLimit,country) " +
-//                             "values ('James', 'Clerk', 350, 5000.75, 'USA')");
-//         var e2 = checkpanic dbClient->execute("Insert into Customers (firstName,lastName,registrationID,creditLimit,country) " +
-//                             "values ('James', 'Clerk', 350, 5000.75, 'USA')");
-//         checkpanic commit;
-//     }
-//     //Check whether the update action is performed.
-//     int count = getCount(dbClient, "350");
-//     checkpanic dbClient.close();
-//     test:assertEquals(count, 2);
-// }
+@test:Config {
+    groups: ["transaction", "local-transaction"],
+    dependsOn: ["testTransactionWithoutHandlers"]
+}
+function testLocalTransactionFailed() {
+    Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
 
-// @test:Config {
-//     groups: ["transaction", "local-transaction"],
-//     dependsOn: ["testTransactionWithoutHandlers"]
-// }
-// function testLocalTransactionFailed() {
-//     Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
+    string a = "beforetx";
 
-//     string a = "beforetx";
+    var ret = trap testLocalTransactionFailedHelper(a, dbClient);
+    if (ret is string) {
+        a = ret;
+    } else {
+        a = ret.message() + " trapped";
+    }
+    a = a + " afterTrx";
+    int count = getCount(dbClient, "111");
+    checkpanic dbClient.close();
+    test:assertEquals(a, "beforetx inTrx trxAborted inTrx trxAborted inTrx trapped afterTrx");
+    test:assertEquals(count, 0);
+}
 
-//     var ret = trap testLocalTransactionFailedHelper(a, dbClient);
-//     if (ret is string) {
-//         a = ret;
-//     } else {
-//         a = ret.message() + " trapped";
-//     }
-//     a = a + " afterTrx";
-//     int count = getCount(dbClient, "111");
-//     checkpanic dbClient.close();
-//     test:assertEquals(a, "beforetx inTrx trxAborted inTrx trxAborted inTrx trapped afterTrx");
-//     test:assertEquals(count, 0);
-// }
+function testLocalTransactionFailedHelper(string status,Client dbClient) returns string|error {
+    string a = status;
+    transactions:Info transInfo;
+    int i = 0;
 
-// function testLocalTransactionFailedHelper(string status,Client dbClient) returns string|error {
-//     string a = status;
-//     transactions:Info transInfo;
-//     int i = 0;
+    var onRollbackFunc = function(transactions:Info? info, error? cause, boolean willTry) {
+        a = a + " trxAborted";
+    };
 
-//     var onRollbackFunc = function(transactions:Info? info, error? cause, boolean willTry) {
-//         a = a + " trxAborted";
-//     };
+    retry(2) transaction {
+        a = a + " inTrx";
+        transInfo = transactions:info();
+        transactions:onRollback(onRollbackFunc);
+        var e1 = check dbClient->execute("Insert into Customers (firstName,lastName,registrationID,creditLimit,country) " +
+                        "values ('James', 'Clerk', 111, 5000.75, 'USA')");
+        var e2 = dbClient->execute("Insert into Customers2 (firstName,lastName,registrationID,creditLimit,country) " +
+                        "values ('Anne', 'Clerk', 111, 5000.75, 'USA')");
+        if(e2 is error){
+           check getError(a);
+        }
+        check commit;
+    }
+    return a;
+}
 
-//     retry(2) transaction {
-//         a = a + " inTrx";
-//         transInfo = transactions:info();
-//         transactions:onRollback(onRollbackFunc);
-//         var e1 = check dbClient->execute("Insert into Customers (firstName,lastName,registrationID,creditLimit,country) " +
-//                         "values ('James', 'Clerk', 111, 5000.75, 'USA')");
-//         var e2 = dbClient->execute("Insert into Customers2 (firstName,lastName,registrationID,creditLimit,country) " +
-//                         "values ('Anne', 'Clerk', 111, 5000.75, 'USA')");
-//         if(e2 is error){
-//            check getError(a);
-//         }
-//         check commit;
-//     }
-//     return a;
-// }
+function getError(string message) returns error? {
+    return error(message);
+}
 
-// function getError(string message) returns error? {
-//     return error(message);
-// }
+@test:Config {
+    groups: ["transaction", "local-transaction"],
+    dependsOn: ["testLocalTransactionFailed"]
+}
+function testLocalTransactionSuccessWithFailed() {
+    Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
 
-// @test:Config {
-//     groups: ["transaction", "local-transaction"],
-//     dependsOn: ["testLocalTransactionFailed"]
-// }
-// function testLocalTransactionSuccessWithFailed() {
-//     Client dbClient = checkpanic new (host, user, password, localTransactionDB, port);
+    string a = "beforetx";
+    string | error ret = trap testLocalTransactionSuccessWithFailedHelper(a, dbClient);
+    if (ret is string) {
+        a = ret;
+    } else {
+        a = a + "trapped";
+    }
+    a = a + " afterTrx";
+    int count = getCount(dbClient, "222");
+    checkpanic dbClient.close();
+     test:assertEquals(a, "beforetx inTrx inTrx inTrx committed afterTrx");
+    test:assertEquals(count, 2);
+}
 
-//     string a = "beforetx";
-//     string | error ret = trap testLocalTransactionSuccessWithFailedHelper(a, dbClient);
-//     if (ret is string) {
-//         a = ret;
-//     } else {
-//         a = a + "trapped";
-//     }
-//     a = a + " afterTrx";
-//     int count = getCount(dbClient, "222");
-//     checkpanic dbClient.close();
-//      test:assertEquals(a, "beforetx inTrx inTrx inTrx committed afterTrx");
-//     test:assertEquals(count, 2);
-// }
+function testLocalTransactionSuccessWithFailedHelper(string status,Client dbClient) returns string|error {
+    int i = 0;
+    string a = status;
+    retry (3) transaction {
+        i = i + 1;
+        a = a + " inTrx";
+        var e1 = check dbClient->execute("Insert into Customers (firstName,lastName,registrationID,creditLimit,country)" +
+                                    " values ('James', 'Clerk', 222, 5000.75, 'USA')");
+        if (i == 3) {
+            var e2 = check dbClient->execute("Insert into Customers (firstName,lastName,registrationID,creditLimit,country) " +
+                                        "values ('Anne', 'Clerk', 222, 5000.75, 'USA')");
+        } else {
+            var e3 = check dbClient->execute("Insert into Customers2 (firstName,lastName,registrationID,creditLimit,country) " +
+                                        "values ('Anne', 'Clerk', 222, 5000.75, 'USA')");
+        }
+        check commit;
+        a = a + " committed";
+    }
+    return a;
+}
 
-// function testLocalTransactionSuccessWithFailedHelper(string status,Client dbClient) returns string|error {
-//     int i = 0;
-//     string a = status;
-//     retry (3) transaction {
-//         i = i + 1;
-//         a = a + " inTrx";
-//         var e1 = check dbClient->execute("Insert into Customers (firstName,lastName,registrationID,creditLimit,country)" +
-//                                     " values ('James', 'Clerk', 222, 5000.75, 'USA')");
-//         if (i == 3) {
-//             var e2 = check dbClient->execute("Insert into Customers (firstName,lastName,registrationID,creditLimit,country) " +
-//                                         "values ('Anne', 'Clerk', 222, 5000.75, 'USA')");
-//         } else {
-//             var e3 = check dbClient->execute("Insert into Customers2 (firstName,lastName,registrationID,creditLimit,country) " +
-//                                         "values ('Anne', 'Clerk', 222, 5000.75, 'USA')");
-//         }
-//         check commit;
-//         a = a + " committed";
-//     }
-//     return a;
-// }
-
-// function getCount(Client dbClient, string id) returns @tainted int {
-//     stream<TransactionResultCount, sql:Error> streamData = <stream<TransactionResultCount, sql:Error>> dbClient->query("Select COUNT(*) as " +
-//         "countval from Customers where registrationID = "+ id, TransactionResultCount);
-//         record {|TransactionResultCount value;|}? data = checkpanic streamData.next();
-//         checkpanic streamData.close();
-//         TransactionResultCount? value = data?.value;
-//         if(value is TransactionResultCount){
-//            return value["COUNTVAL"];
-//         }
-//         return 0;
-// }
+function getCount(Client dbClient, string id) returns @tainted int {
+    stream<TransactionResultCount, sql:Error> streamData = <stream<TransactionResultCount, sql:Error>> dbClient->query("Select COUNT(*) as " +
+        "countval from Customers where registrationID = "+ id, TransactionResultCount);
+        record {|TransactionResultCount value;|}? data = checkpanic streamData.next();
+        checkpanic streamData.close();
+        TransactionResultCount? value = data?.value;
+        if(value is TransactionResultCount){
+           return value["COUNTVAL"];
+        }
+        return 0;
+}

--- a/mysql-ballerina/src/mysql/tests/transaction/xa-transactions-test.bal
+++ b/mysql-ballerina/src/mysql/tests/transaction/xa-transactions-test.bal
@@ -84,7 +84,7 @@ function getSalaryCount(Client dbClient, string id) returns @tainted int|error{
     return getResult(streamData);
 }
 
-function getResult(stream<XAResultCount, error> streamData) returns int{
+isolated function getResult(stream<XAResultCount, error> streamData) returns int{
     record {|XAResultCount value;|}? data = checkpanic streamData.next();
     checkpanic streamData.close();
     XAResultCount? value = data?.value;

--- a/mysql-ballerina/src/mysql/tests/transaction/xa-transactions-test.bal
+++ b/mysql-ballerina/src/mysql/tests/transaction/xa-transactions-test.bal
@@ -14,85 +14,82 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// todo Disabling due to https://github.com/ballerina-platform/ballerina-lang/issues/26972
-// Since its a compiler issue this needs to be commented out
+import ballerina/test;
 
-// import ballerina/test;
+string xaTransactionDB1 = "XA_TRANSACTION_1";
+string xaTransactionDB2 = "XA_TRANSACTION_2";
 
-// string xaTransactionDB1 = "XA_TRANSACTION_1";
-// string xaTransactionDB2 = "XA_TRANSACTION_2";
+type XAResultCount record {
+    int COUNTVAL;
+};
 
-// type XAResultCount record {
-//     int COUNTVAL;
-// };
+@test:Config {
+    groups: ["transaction", "xa-transaction"]
+}
+function testXATransactionSuccess() {
+    Client dbClient1 = checkpanic new (host, user, password, xaTransactionDB1, port,
+    connectionPool = {maxOpenConnections: 1});
+    Client dbClient2 = checkpanic new (host, user, password, xaTransactionDB2, port,
+    connectionPool = {maxOpenConnections: 1});
 
-// @test:Config {
-//     groups: ["transaction", "xa-transaction"]
-// }
-// function testXATransactionSuccess() {
-//     Client dbClient1 = checkpanic new (host, user, password, xaTransactionDB1, port,
-//     connectionPool = {maxOpenConnections: 1});
-//     Client dbClient2 = checkpanic new (host, user, password, xaTransactionDB2, port,
-//     connectionPool = {maxOpenConnections: 1});
+    transaction {
+        var e1 = checkpanic dbClient1->execute("insert into Customers (customerId, name, creditLimit, country) " +
+                                "values (1, 'Anne', 1000, 'UK')");
+        var e2 = checkpanic dbClient2->execute("insert into Salary (id, value ) values (1, 1000)");
+        checkpanic commit;
+    }
 
-//     transaction {
-//         var e1 = checkpanic dbClient1->execute("insert into Customers (customerId, name, creditLimit, country) " +
-//                                 "values (1, 'Anne', 1000, 'UK')");
-//         var e2 = checkpanic dbClient2->execute("insert into Salary (id, value ) values (1, 1000)");
-//         checkpanic commit;
-//     }
+    int count1 = checkpanic getCustomerCount(dbClient1, "1");
+    int count2 = checkpanic getSalaryCount(dbClient2, "1");
+    test:assertEquals(count1, 1, "First transaction failed"); 
+    test:assertEquals(count2, 1, "Second transaction failed"); 
 
-//     int count1 = checkpanic getCustomerCount(dbClient1, "1");
-//     int count2 = checkpanic getSalaryCount(dbClient2, "1");
-//     test:assertEquals(count1, 1, "First transaction failed"); 
-//     test:assertEquals(count2, 1, "Second transaction failed"); 
+    checkpanic dbClient1.close();
+    checkpanic dbClient2.close();
+}
 
-//     checkpanic dbClient1.close();
-//     checkpanic dbClient2.close();
-// }
-
-// @test:Config {
-//     groups: ["transaction", "xa-transaction"]
-// }
-// function testXATransactionSuccessWithDataSource() {
-//     Client dbClient1 = checkpanic new (host, user, password, xaTransactionDB1, port);
-//     Client dbClient2 = checkpanic new (host, user, password, xaTransactionDB2, port);
+@test:Config {
+    groups: ["transaction", "xa-transaction"]
+}
+function testXATransactionSuccessWithDataSource() {
+    Client dbClient1 = checkpanic new (host, user, password, xaTransactionDB1, port);
+    Client dbClient2 = checkpanic new (host, user, password, xaTransactionDB2, port);
     
-//     transaction {
-//         var e1 = checkpanic dbClient1->execute("insert into Customers (customerId, name, creditLimit, country) " +
-//                                 "values (10, 'Anne', 1000, 'UK')");
-//         var e2 = checkpanic dbClient2->execute("insert into Salary (id, value ) values (10, 1000)");
-//         checkpanic commit;
-//     }
+    transaction {
+        var e1 = checkpanic dbClient1->execute("insert into Customers (customerId, name, creditLimit, country) " +
+                                "values (10, 'Anne', 1000, 'UK')");
+        var e2 = checkpanic dbClient2->execute("insert into Salary (id, value ) values (10, 1000)");
+        checkpanic commit;
+    }
     
-//     int count1 = checkpanic getCustomerCount(dbClient1, "10");
-//     int count2 = checkpanic getSalaryCount(dbClient2, "10");
-//     test:assertEquals(count1, 1, "First transaction failed"); 
-//     test:assertEquals(count2, 1, "Second transaction failed"); 
+    int count1 = checkpanic getCustomerCount(dbClient1, "10");
+    int count2 = checkpanic getSalaryCount(dbClient2, "10");
+    test:assertEquals(count1, 1, "First transaction failed"); 
+    test:assertEquals(count2, 1, "Second transaction failed"); 
 
-//     checkpanic dbClient1.close();
-//     checkpanic dbClient2.close();
-// }
+    checkpanic dbClient1.close();
+    checkpanic dbClient2.close();
+}
 
-// function getCustomerCount(Client dbClient, string id) returns @tainted int|error{
-//     stream<XAResultCount, error> streamData = <stream<XAResultCount, error>> dbClient->query("Select COUNT(*) as " +
-//         "countval from Customers where customerId = "+ id, XAResultCount);
-//     return getResult(streamData);
-// }
+function getCustomerCount(Client dbClient, string id) returns @tainted int|error{
+    stream<XAResultCount, error> streamData = <stream<XAResultCount, error>> dbClient->query("Select COUNT(*) as " +
+        "countval from Customers where customerId = "+ id, XAResultCount);
+    return getResult(streamData);
+}
 
-// function getSalaryCount(Client dbClient, string id) returns @tainted int|error{
-//     stream<XAResultCount, error> streamData =
-//     <stream<XAResultCount, error>> dbClient->query("Select COUNT(*) as countval " +
-//     "from Salary where id = "+ id, XAResultCount);
-//     return getResult(streamData);
-// }
+function getSalaryCount(Client dbClient, string id) returns @tainted int|error{
+    stream<XAResultCount, error> streamData =
+    <stream<XAResultCount, error>> dbClient->query("Select COUNT(*) as countval " +
+    "from Salary where id = "+ id, XAResultCount);
+    return getResult(streamData);
+}
 
-// function getResult(stream<XAResultCount, error> streamData) returns int{
-//     record {|XAResultCount value;|}? data = checkpanic streamData.next();
-//     checkpanic streamData.close();
-//     XAResultCount? value = data?.value;
-//     if(value is XAResultCount){
-//        return value.COUNTVAL;
-//     }
-//     return 0;
-// }
+function getResult(stream<XAResultCount, error> streamData) returns int{
+    record {|XAResultCount value;|}? data = checkpanic streamData.next();
+    checkpanic streamData.close();
+    XAResultCount? value = data?.value;
+    if(value is XAResultCount){
+       return value.COUNTVAL;
+    }
+    return 0;
+}


### PR DESCRIPTION

## Purpose
This reverts commit 01fa3682 as the original issue is fixed by https://github.com/ballerina-platform/ballerina-lang/pull/26999

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes