### PR TITLE
Add Codecov Report Generation

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -39,6 +39,8 @@ jobs:
           name: Code Coverage JSON
           path: mysql-ballerina/target/report/test_results.json
           if-no-files-found: ignore
+      - name: Generate Codecov Report
+        uses: codecov/codecov-action@v1
       - name: Dispatch Dependent Module Builds
         if: github.event.action != 'stdlib-publish-snapshot'
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -33,6 +33,9 @@ jobs:
           name: Code Coverage JSON
           path: mysql-ballerina/target/report/test_results.json
           if-no-files-found: ignore
+      - name: Generate Codecov Report
+        if:  github.event_name == 'pull_request'
+        uses: codecov/codecov-action@v1
   windows-build:
     runs-on: windows-latest
     steps:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+fixes:
+  - "ballerinax/mysql/*/::mysql-ballerina/"
+
+ignore:
+  - "**/tests"
+


### PR DESCRIPTION
## Purpose
- Introducing `Codecov` code coverage report publishing to the `mysql` repository

## Goals
- Publishing the testerina generated code coverage xml to `Codecov` triggered via GitHub action of PR.

## Approach
- A new job is inserted to `Pull request` and `Build Master` GitHub actions that publishes the XML report to  `Codecov`.
- These jobs trigger on push or pull request and `CodeCov` generates a descriptive code coverage report.
- `Codecov` adds comments to any PR made based on the code coverage changes between commits

## Test environment
- Ubuntu 20.04