### PR TITLE
Add Tooling support for MySQL connectors 

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -12,7 +12,7 @@ distribution = "slbeta3"
 path = "../native/build/libs/mysql-native-1.1.0-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
-path = "./lib/sql-native-1.1.0-20211115-201400-bd1fcce.jar"
+path = "./lib/sql-native-1.1.0-20211118-095300-f0a760a.jar"
 
 [[platform.java11.dependency]]
 path = "./lib/mysql-connector-java-8.0.21.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -1,0 +1,6 @@
+[plugin]
+id = "mysql-compiler-plugin"
+class = "io.ballerina.stdlib.mysql.compiler.MySQLCompilerPlugin"
+
+[[dependency]]
+path = "../compiler-plugin/build/libs/mysql-compiler-plugin-1.1.0-SNAPSHOT.jar"

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -37,8 +37,11 @@ description = 'Ballerina - MySQL Ballerina Generator'
 def packageName = 'mysql'
 def packageOrg = 'ballerinax'
 def tomlVersion = stripBallerinaExtensionVersion("${project.version}")
+
 def ballerinaTomlFilePlaceHolder = new File("${project.rootDir}/build-config/resources/Ballerina.toml")
+def compilerPluginTomlFilePlaceHolder = new File("${project.rootDir}/build-config/resources/CompilerPlugin.toml")
 def ballerinaTomlFile = new File("$project.projectDir/Ballerina.toml")
+def compilerPluginTomlFile = new File("$project.projectDir/CompilerPlugin.toml")
 
 def stripBallerinaExtensionVersion(String extVersion) {
     if (extVersion.matches(project.ext.timestampedVersionRegex)) {
@@ -77,8 +80,10 @@ task updateTomlFiles {
         newConfig = newConfig.replace('@sql.native.version@', project.stdlibSqlVersion)
         newConfig = newConfig.replace('@mysql.driver.version@', project.mySQLDriverVersion)
         newConfig = newConfig.replace('@stdlib.sql.version@', stdlibDependentSqlVersion)
-
         ballerinaTomlFile.text = newConfig
+
+        def newCompilerPluginToml = compilerPluginTomlFilePlaceHolder.text.replace("@project.version@", project.version)
+        compilerPluginTomlFile.text = newCompilerPluginToml
     }
 }
 
@@ -87,9 +92,9 @@ task commitTomlFiles {
         project.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml"
+                commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml CompilerPlugin.toml"
             } else {
-                commandLine 'sh', '-c', "git commit -m '[Automated] Update the native jar versions' Ballerina.toml Dependencies.toml"
+                commandLine 'sh', '-c', "git commit -m '[Automated] Update the native jar versions' Ballerina.toml Dependencies.toml CompilerPlugin.toml"
             }
         }
     }
@@ -233,6 +238,8 @@ startTestSslDockerContainer.dependsOn createTestDockerImage
 build.dependsOn "generatePomFileForMavenPublication"
 build.dependsOn ":${packageName}-native:build"
 test.dependsOn ":${packageName}-native:build"
+build.dependsOn ":${packageName}-compiler-plugin:build"
+test.dependsOn ":${packageName}-compiler-plugin:build"
 build.finalizedBy stopTestDockerContainer
 build.finalizedBy stopTestSslDockerContainer
 test.dependsOn startTestDockerContainer

--- a/ballerina/tests/error.bal
+++ b/ballerina/tests/error.bal
@@ -232,16 +232,16 @@ function TestTableDefinitionIncorrect() returns error? {
 }
 function TestIntegrityConstraintViolation() returns error? {
     Client dbClient = check new (host, user, password, errorDB, port);
-    sql:ExecutionResult|error result = check dbClient->execute(`CREATE TABLE employees( employee_id int (20) not null,
+    _ = check dbClient->execute(`CREATE TABLE employees( employee_id int (20) not null,
                                                         employee_name varchar (75) not null,supervisor_name varchar(75),
                                                         CONSTRAINT employee_pk PRIMARY KEY (employee_id))`);
-    result = check dbClient->execute(`CREATE TABLE departments( department_id int (20) not null,employee_id int not
+    _ = check dbClient->execute(`CREATE TABLE departments( department_id int (20) not null,employee_id int not
                                        null,CONSTRAINT fk_employee FOREIGN KEY (employee_id)
                                        REFERENCES employees (employee_id))`);
     sql:ExecutionResult|error err = dbClient->execute(
                                     `INSERT INTO departments(department_id, employee_id) VALUES (250, 600)`);
     check dbClient.close();
-    sql:DatabaseError sqlerror = <sql:DatabaseError>err;
+    sql:DatabaseError sqlerror = <sql:DatabaseError> err;
     test:assertTrue(strings:includes(sqlerror.message(), "Error while executing SQL query: INSERT INTO " +
                 "departments(department_id, employee_id) VALUES (250, 600). Cannot add or update a child row: " +
                 "a foreign key constraint fails (`ERROR_DB`.`departments`, CONSTRAINT " +

--- a/build-config/resources/CompilerPlugin.toml
+++ b/build-config/resources/CompilerPlugin.toml
@@ -1,0 +1,6 @@
+[plugin]
+id = "mysql-compiler-plugin"
+class = "io.ballerina.stdlib.mysql.compiler.MySQLCompilerPlugin"
+
+[[dependency]]
+path = "../compiler-plugin/build/libs/mysql-compiler-plugin-@project.version@.jar"

--- a/build.gradle
+++ b/build.gradle
@@ -116,5 +116,6 @@ release {
 }
 
 task build {
+    dependsOn("${packageName}-native:build")
     dependsOn("${packageName}-ballerina:build")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -118,4 +118,5 @@ release {
 task build {
     dependsOn("${packageName}-native:build")
     dependsOn("${packageName}-ballerina:build")
+    dependsOn("${packageName}-compiler-plugin-tests:build")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ release {
 
 task build {
     dependsOn("${packageName}-native:build")
+    dependsOn("${packageName}-compiler-plugin:build")
     dependsOn("${packageName}-ballerina:build")
     dependsOn("${packageName}-compiler-plugin-tests:build")
 }

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [Support noAccessToProcedureBodies options in mysql connector](https://github.com/ballerina-platform/ballerina-standard-library/issues/1545)
 - [Support Mysql connector failover and retries](https://github.com/ballerina-platform/ballerina-standard-library/issues/1950)
+- [Add Tooling support for MySLQ connector](https://github.com/ballerina-platform/ballerina-standard-library/issues/2279)
 
 ### Changed
 - [Change queryRow return type to anydata](https://github.com/ballerina-platform/ballerina-standard-library/issues/2390)

--- a/compiler-plugin-tests/build.gradle
+++ b/compiler-plugin-tests/build.gradle
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+    id 'java'
+    id 'checkstyle'
+    id 'com.github.spotbugs'
+}
+
+description = 'Ballerina - MySQL Compiler Plugin Tests'
+
+dependencies {
+    checkstyle project(':checkstyle')
+    checkstyle "com.puppycrawl.tools:checkstyle:${puppycrawlCheckstyleVersion}"
+
+    // implementation project(':mysql-compiler-plugin')
+
+    testImplementation group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
+    testImplementation group: 'org.ballerinalang', name: 'ballerina-tools-api', version: "${ballerinaLangVersion}"
+    testImplementation group: 'org.ballerinalang', name: 'ballerina-parser', version: "${ballerinaLangVersion}"
+
+    implementation group: 'org.testng', name: 'testng', version: "${testngVersion}"
+}
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+
+sourceCompatibility = JavaVersion.VERSION_11
+
+test {
+    systemProperty "ballerina.offline.flag", "true"
+    useTestNG() {
+        suites 'src/test/resources/testng.xml'
+    }
+    testLogging.showStandardStreams = true
+    testLogging {
+        events "PASSED", "FAILED", "SKIPPED"
+        afterSuite { desc, result ->
+            if (!desc.parent) { // will match the outermost suite
+                def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} successes, ${result.failedTestCount} failures, ${result.skippedTestCount} skipped)"
+                def startItem = '|  ', endItem = '  |'
+                def repeatLength = startItem.length() + output.length() + endItem.length()
+                println('\n' + ('-' * repeatLength) + '\n' + startItem + output + endItem + '\n' + ('-' * repeatLength))
+            }
+        }
+    }
+}
+
+spotbugsTest {
+    ignoreFailures = true
+    effort = "max"
+    reportLevel = "low"
+    reportsDir = file("$project.buildDir/reports/spotbugs")
+    def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
+    if (excludeFile.exists()) {
+        it.excludeFilter = excludeFile
+    }
+    reports {
+        text.enabled = true
+    }
+}
+
+spotbugsMain {
+    enabled false
+}
+
+task validateSpotbugs() {
+    doLast {
+        if (spotbugsMain.reports.size() > 0 &&
+                spotbugsMain.reports[0].destination.exists() &&
+                spotbugsMain.reports[0].destination.text.readLines().size() > 0) {
+            spotbugsMain.reports[0].destination?.eachLine {
+                println 'Failure: ' + it
+            }
+            throw new GradleException("Spotbugs rule violations were found.");
+        }
+    }
+}
+
+tasks.withType(Checkstyle) {
+    exclude '**/module-info.java'
+}
+
+checkstyle {
+    toolVersion "${project.puppycrawlCheckstyleVersion}"
+    configFile rootProject.file("build-config/checkstyle/build/checkstyle.xml")
+    configProperties = ["suppressionFile": file("${rootDir}/build-config/checkstyle/build/suppressions.xml")]
+}
+
+checkstyleMain {
+    enabled false
+}
+
+spotbugsTest.finalizedBy validateSpotbugs
+checkstyleTest.dependsOn ':checkstyle:downloadCheckstyleRuleFiles'
+
+compileJava {
+    doFirst {
+        options.compilerArgs = [
+                '--module-path', classpath.asPath,
+        ]
+        classpath = files()
+    }
+}
+
+test.dependsOn ":mysql-ballerina:build"
+build.dependsOn ":mysql-ballerina:build"

--- a/compiler-plugin-tests/build.gradle
+++ b/compiler-plugin-tests/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     checkstyle project(':checkstyle')
     checkstyle "com.puppycrawl.tools:checkstyle:${puppycrawlCheckstyleVersion}"
 
-    // implementation project(':mysql-compiler-plugin')
+    implementation project(':mysql-compiler-plugin')
 
     testImplementation group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
     testImplementation group: 'org.ballerinalang', name: 'ballerina-tools-api', version: "${ballerinaLangVersion}"

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mysql/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mysql/compiler/CompilerPluginTest.java
@@ -37,7 +37,7 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static io.ballerina.stdlib.mysql.compiler.MySQLDiagnosticsCode.SQL_101;
+import static io.ballerina.stdlib.mysql.compiler.MySQLDiagnosticsCode.MYSQL_101;
 
 /**
  * Tests the custom SQL compiler plugin.
@@ -76,16 +76,16 @@ public class CompilerPluginTest {
         Assert.assertEquals(availableHints, 3);
 
         DiagnosticInfo hint1 = diagnosticHints.get(0).diagnosticInfo();
-        Assert.assertEquals(hint1.code(), MySQLDiagnosticsCode.MYSQL_101.getCode());
-        Assert.assertEquals(hint1.messageFormat(), MySQLDiagnosticsCode.MYSQL_101.getMessage());
+        Assert.assertEquals(hint1.code(), MySQLDiagnosticsCode.MYSQL_901.getCode());
+        Assert.assertEquals(hint1.messageFormat(), MySQLDiagnosticsCode.MYSQL_901.getMessage());
 
         DiagnosticInfo hint2 = diagnosticHints.get(1).diagnosticInfo();
-        Assert.assertEquals(hint2.code(), MySQLDiagnosticsCode.MYSQL_102.getCode());
-        Assert.assertEquals(hint2.messageFormat(), MySQLDiagnosticsCode.MYSQL_102.getMessage());
+        Assert.assertEquals(hint2.code(), MySQLDiagnosticsCode.MYSQL_902.getCode());
+        Assert.assertEquals(hint2.messageFormat(), MySQLDiagnosticsCode.MYSQL_902.getMessage());
 
         DiagnosticInfo hint3 = diagnosticHints.get(2).diagnosticInfo();
-        Assert.assertEquals(hint3.code(), MySQLDiagnosticsCode.MYSQL_101.getCode());
-        Assert.assertEquals(hint3.messageFormat(), MySQLDiagnosticsCode.MYSQL_101.getMessage());
+        Assert.assertEquals(hint3.code(), MySQLDiagnosticsCode.MYSQL_901.getCode());
+        Assert.assertEquals(hint3.messageFormat(), MySQLDiagnosticsCode.MYSQL_901.getMessage());
     }
 
     @Test
@@ -98,11 +98,41 @@ public class CompilerPluginTest {
                 .collect(Collectors.toList());
         long availableErrors = diagnosticErrorStream.size();
 
-        Assert.assertEquals(availableErrors, 2);
+        Assert.assertEquals(availableErrors, 5);
+
+        for (int i = 0; i < diagnosticErrorStream.size(); i++) {
+            Diagnostic diagnostic = diagnosticErrorStream.get(i);
+            switch (i) {
+                case 0:
+                case 3:
+                case 4:
+                    Assert.assertEquals(diagnostic.diagnosticInfo().code(), MYSQL_101.getCode());
+                    Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(),
+                            MYSQL_101.getMessage());
+                    break;
+                default:
+                    Assert.assertEquals(diagnostic.diagnosticInfo().code(), MySQLDiagnosticsCode.SQL_101.getCode());
+                    Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(),
+                            MySQLDiagnosticsCode.SQL_101.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void testMySQLRecords() {
+        Package currentPackage = loadPackage("sample3");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        List<Diagnostic> diagnosticErrorStream = diagnosticResult.diagnostics().stream()
+                .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR))
+                .collect(Collectors.toList());
+        long availableErrors = diagnosticErrorStream.size();
+
+        Assert.assertEquals(availableErrors, 10);
 
         diagnosticErrorStream.forEach(diagnostic -> {
-            Assert.assertEquals(diagnostic.diagnosticInfo().code(), SQL_101.getCode());
-            Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(), SQL_101.getMessage());
+            Assert.assertEquals(diagnostic.diagnosticInfo().code(), MYSQL_101.getCode());
+            Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(), MYSQL_101.getMessage());
         });
     }
 }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mysql/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mysql/compiler/CompilerPluginTest.java
@@ -37,6 +37,8 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static io.ballerina.stdlib.mysql.compiler.MySQLDiagnosticsCode.SQL_101;
+
 /**
  * Tests the custom SQL compiler plugin.
  */
@@ -84,5 +86,23 @@ public class CompilerPluginTest {
         DiagnosticInfo hint3 = diagnosticHints.get(2).diagnosticInfo();
         Assert.assertEquals(hint3.code(), MySQLDiagnosticsCode.MYSQL_101.getCode());
         Assert.assertEquals(hint3.messageFormat(), MySQLDiagnosticsCode.MYSQL_101.getMessage());
+    }
+
+    @Test
+    public void testSQLConnectionPoolFieldsInNewExpression() {
+        Package currentPackage = loadPackage("sample2");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        List<Diagnostic> diagnosticErrorStream = diagnosticResult.diagnostics().stream()
+                .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR))
+                .collect(Collectors.toList());
+        long availableErrors = diagnosticErrorStream.size();
+
+        Assert.assertEquals(availableErrors, 2);
+
+        diagnosticErrorStream.forEach(diagnostic -> {
+            Assert.assertEquals(diagnostic.diagnosticInfo().code(), SQL_101.getCode());
+            Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(), SQL_101.getMessage());
+        });
     }
 }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mysql/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mysql/compiler/CompilerPluginTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.mysql.compiler;
+
+
+import io.ballerina.projects.DiagnosticResult;
+import io.ballerina.projects.Package;
+import io.ballerina.projects.PackageCompilation;
+import io.ballerina.projects.ProjectEnvironmentBuilder;
+import io.ballerina.projects.directory.BuildProject;
+import io.ballerina.projects.environment.Environment;
+import io.ballerina.projects.environment.EnvironmentBuilder;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Tests the custom SQL compiler plugin.
+ */
+public class CompilerPluginTest {
+
+    private static final Path RESOURCE_DIRECTORY = Paths.get("src", "test", "resources", "diagnostics")
+            .toAbsolutePath();
+    private static final Path DISTRIBUTION_PATH = Paths.get("../", "target", "ballerina-runtime")
+            .toAbsolutePath();
+
+    private static ProjectEnvironmentBuilder getEnvironmentBuilder() {
+        Environment environment = EnvironmentBuilder.getBuilder().setBallerinaHome(DISTRIBUTION_PATH).build();
+        return ProjectEnvironmentBuilder.getBuilder(environment);
+    }
+
+    private Package loadPackage(String path) {
+        Path projectDirPath = RESOURCE_DIRECTORY.resolve(path);
+        BuildProject project = BuildProject.load(getEnvironmentBuilder(), projectDirPath);
+        return project.currentPackage();
+    }
+
+    @Test
+    public void testBatchExecuteParam() {
+        Package currentPackage = loadPackage("sample1");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        long availableErrors = diagnosticResult.diagnostics().stream()
+                .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR)).count();
+        Assert.assertEquals(availableErrors, 0);
+    }
+
+}

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mysql/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mysql/compiler/CompilerPluginTest.java
@@ -18,7 +18,6 @@
 
 package io.ballerina.stdlib.mysql.compiler;
 
-
 import io.ballerina.projects.DiagnosticResult;
 import io.ballerina.projects.Package;
 import io.ballerina.projects.PackageCompilation;

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mysql/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mysql/compiler/CompilerPluginTest.java
@@ -26,12 +26,16 @@ import io.ballerina.projects.ProjectEnvironmentBuilder;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.environment.Environment;
 import io.ballerina.projects.environment.EnvironmentBuilder;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticInfo;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Tests the custom SQL compiler plugin.
@@ -55,13 +59,30 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testBatchExecuteParam() {
+    public void testFunctionHints() {
         Package currentPackage = loadPackage("sample1");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
         long availableErrors = diagnosticResult.diagnostics().stream()
                 .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR)).count();
-        Assert.assertEquals(availableErrors, 0);
-    }
+        Assert.assertEquals(availableErrors, 3);
 
+        List<Diagnostic> diagnosticHints = diagnosticResult.diagnostics().stream()
+                .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.HINT))
+                .collect(Collectors.toList());
+        long availableHints = diagnosticHints.size();
+        Assert.assertEquals(availableHints, 3);
+
+        DiagnosticInfo hint1 = diagnosticHints.get(0).diagnosticInfo();
+        Assert.assertEquals(hint1.code(), MySQLDiagnosticsCode.MYSQL_101.getCode());
+        Assert.assertEquals(hint1.messageFormat(), MySQLDiagnosticsCode.MYSQL_101.getMessage());
+
+        DiagnosticInfo hint2 = diagnosticHints.get(1).diagnosticInfo();
+        Assert.assertEquals(hint2.code(), MySQLDiagnosticsCode.MYSQL_102.getCode());
+        Assert.assertEquals(hint2.messageFormat(), MySQLDiagnosticsCode.MYSQL_102.getMessage());
+
+        DiagnosticInfo hint3 = diagnosticHints.get(2).diagnosticInfo();
+        Assert.assertEquals(hint3.code(), MySQLDiagnosticsCode.MYSQL_101.getCode());
+        Assert.assertEquals(hint3.messageFormat(), MySQLDiagnosticsCode.MYSQL_101.getMessage());
+    }
 }

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample1/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample1/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "mysql_test"
+name = "sample1"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample1/main.bal
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample1/main.bal
@@ -1,0 +1,22 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/mysql;
+
+public function main() returns error? {
+    mysql:Client dbClient = check new();
+    check dbClient.close();
+}

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample1/main.bal
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample1/main.bal
@@ -18,5 +18,12 @@ import ballerinax/mysql;
 
 public function main() returns error? {
     mysql:Client dbClient = check new();
+    _ = check dbClient->query(``);
+    _ = check dbClient->queryRow(``);
+    check invokeQuery(dbClient);
     check dbClient.close();
+}
+
+function invokeQuery(mysql:Client dbClient) returns error? {
+    _ = check dbClient->query(``);
 }

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample2/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample2/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "mysql_test"
+name = "sample2"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample2/main.bal
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample2/main.bal
@@ -1,0 +1,31 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/mysql;
+
+mysql:Client dbClient = check new mysql:Client("url", (), (), (), 120, {}, { maxOpenConnections: -1 });
+
+public function main() returns error? {
+
+    mysql:Client dbClient1 = check new("url", connectionPool = { maxOpenConnections: -1 });
+    check dbClient1.close();
+
+    mysql:Client dbClient2 = check new("url", options = {});
+    check dbClient2.close();
+
+    mysql:Client dbClient3 = check new("url", (), (), (), 120, {});
+    check dbClient3.close();
+}

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample2/main.bal
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample2/main.bal
@@ -16,16 +16,16 @@
 
 import ballerinax/mysql;
 
-mysql:Client dbClient = check new mysql:Client("url", (), (), (), 120, {}, { maxOpenConnections: -1 });
+mysql:Client dbClient = check new mysql:Client("url", (), (), (), 120, { connectTimeout: -1 }, { maxOpenConnections: -1 });
 
 public function main() returns error? {
 
     mysql:Client dbClient1 = check new("url", connectionPool = { maxOpenConnections: -1 });
     check dbClient1.close();
 
-    mysql:Client dbClient2 = check new("url", options = {});
+    mysql:Client dbClient2 = check new("url", options = { connectTimeout: -1 });
     check dbClient2.close();
 
-    mysql:Client dbClient3 = check new("url", (), (), (), 120, {});
+    mysql:Client dbClient3 = check new("url", (), (), (), 120, { connectTimeout: -1 });
     check dbClient3.close();
 }

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample3/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample3/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "mysql_test"
+name = "sample3"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample3/main.bal
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample3/main.bal
@@ -1,0 +1,63 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/mysql;
+
+public function main() {
+
+    int id = 5;
+
+    int|mysql:Options pool1 = 5;
+
+    int|mysql:Options pool2 = {
+        connectTimeout: -2,
+        socketTimeout: -3
+    };
+
+    mysql:Options|int pool3 = {
+        connectTimeout: -2,
+        socketTimeout: -3
+    };
+
+    mysql:Options pool4 = {
+        connectTimeout: -2,
+        socketTimeout: -3,
+        failoverConfig: {
+            failoverServers:[],
+            timeBeforeRetry: -2,
+            queriesBeforeRetry: 0
+        }
+    };
+
+    mysql:Options pool5 = {
+        failoverConfig: {
+            failoverServers:[],
+            queriesBeforeRetry: 0
+        }
+    };
+
+    mysql:FailoverConfig pool6 = {
+        failoverServers:[],
+        queriesBeforeRetry: -2,
+        timeBeforeRetry: -4
+    };
+
+    mysql:FailoverConfig pool7 = {
+        failoverServers:[],
+        timeBeforeRetry: -8
+    };
+
+}

--- a/compiler-plugin-tests/src/test/resources/testng.xml
+++ b/compiler-plugin-tests/src/test/resources/testng.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="SQL compiler plugin test suite" parallel="false">
+
+    <test name="SQL Compiler Plugin Tests" parallel="false">
+        <classes>
+            <class name="io.ballerina.stdlib.mysql.compiler.CompilerPluginTest"/>
+        </classes>
+    </test>
+</suite>

--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+    id 'java'
+    id 'checkstyle'
+    id 'com.github.spotbugs'
+}
+
+description = 'Ballerina - MySQL Compiler Plugin'
+
+dependencies {
+    checkstyle project(':checkstyle')
+    checkstyle "com.puppycrawl.tools:checkstyle:${puppycrawlCheckstyleVersion}"
+
+    implementation group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
+    implementation group: 'org.ballerinalang', name: 'ballerina-tools-api', version: "${ballerinaLangVersion}"
+    implementation group: 'org.ballerinalang', name: 'ballerina-parser', version: "${ballerinaLangVersion}"
+}
+
+def excludePattern = '**/module-info.java'
+tasks.withType(Checkstyle) {
+    exclude excludePattern
+}
+
+checkstyle {
+    toolVersion "${project.puppycrawlCheckstyleVersion}"
+    configFile rootProject.file("build-config/checkstyle/build/checkstyle.xml")
+    configProperties = ["suppressionFile" : file("${rootDir}/build-config/checkstyle/build/suppressions.xml")]
+}
+
+checkstyleMain.dependsOn(":checkstyle:downloadCheckstyleRuleFiles")
+
+spotbugsMain {
+    effort "max"
+    reportLevel "low"
+    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reports {
+        html.enabled true
+        text.enabled = true
+    }
+    def excludeFile = file("${rootDir}/spotbugs-exclude.xml")
+    if(excludeFile.exists()) {
+        excludeFilter = excludeFile
+    }
+}
+
+compileJava {
+    doFirst {
+        options.compilerArgs = [
+                '--module-path', classpath.asPath,
+        ]
+        classpath = files()
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/Constants.java
@@ -23,6 +23,7 @@ package io.ballerina.stdlib.mysql.compiler;
 public class Constants {
     public static final String BALLERINAX = "ballerinax";
     public static final String MYSQL = "mysql";
+    public static final String CONNECTION_POOL_PARM_NAME = "connectionPool";
 
     /**
      * Constants related to Client object.
@@ -32,4 +33,16 @@ public class Constants {
         public static final String QUERY = "query";
         public static final String QUERY_ROW = "queryRow";
     }
+
+    /**
+     * Constants for fields in sql:ConnectionPool.
+     */
+    public static class ConnectionPool {
+        public static final String MAX_OPEN_CONNECTIONS = "maxOpenConnections";
+        public static final String MAX_CONNECTION_LIFE_TIME = "maxConnectionLifeTime";
+        public static final String MIN_IDLE_CONNECTIONS = "minIdleConnections";
+    }
+
+    public static final String UNNECESSARY_CHARS_REGEX = "\"|\\n";
+
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/Constants.java
@@ -24,6 +24,7 @@ public class Constants {
     public static final String BALLERINAX = "ballerinax";
     public static final String MYSQL = "mysql";
     public static final String CONNECTION_POOL_PARM_NAME = "connectionPool";
+    public static final String OPTIONS_PARM_NAME = "options";
 
     /**
      * Constants related to Client object.
@@ -41,6 +42,25 @@ public class Constants {
         public static final String MAX_OPEN_CONNECTIONS = "maxOpenConnections";
         public static final String MAX_CONNECTION_LIFE_TIME = "maxConnectionLifeTime";
         public static final String MIN_IDLE_CONNECTIONS = "minIdleConnections";
+    }
+
+    /**
+     * Constants for fields in mysql:Options.
+     */
+    public static class Options {
+        public static final String NAME = "Options";
+        public static final String CONNECTION_TIMEOUT = "connectTimeout";
+        public static final String SOCKET_TIMEOUT = "socketTimeout";
+        public static final String FAILOVER = "failoverConfig";
+    }
+
+    /**
+     * Constants for fields in mysql:FailoverConfig.
+     */
+    public static class FailOver {
+        public static final String NAME = "FailoverConfig";
+        public static final String TIME_BEFORE_RETRY = "timeBeforeRetry";
+        public static final String QUERY_BEFORE_RETRY = "queriesBeforeRetry";
     }
 
     public static final String UNNECESSARY_CHARS_REGEX = "\"|\\n";

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/Constants.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.mysql.compiler;
+
+/**
+ * Constants for MySQL compiler plugin.
+ */
+public class Constants {
+    public static final String BALLERINAX = "ballerinax";
+    public static final String MYSQL = "mysql";
+
+    /**
+     * Constants related to Client object.
+     */
+    public static class Client {
+        public static final String CLIENT = "Client";
+        public static final String QUERY = "query";
+        public static final String QUERY_ROW = "queryRow";
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/MySQLCodeAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/MySQLCodeAnalyzer.java
@@ -21,14 +21,20 @@ package io.ballerina.stdlib.mysql.compiler;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.projects.plugins.CodeAnalysisContext;
 import io.ballerina.projects.plugins.CodeAnalyzer;
+import io.ballerina.stdlib.mysql.compiler.analyzer.InitializerParamAnalyzer;
 import io.ballerina.stdlib.mysql.compiler.analyzer.RemoteMethodAnalyzer;
+
+import java.util.List;
+
 /**
  * JDBC Code Analyzer.
  */
 public class MySQLCodeAnalyzer extends CodeAnalyzer {
 
     @Override
-    public void init(CodeAnalysisContext codeAnalysisContext) {
-        codeAnalysisContext.addSyntaxNodeAnalysisTask(new RemoteMethodAnalyzer(), SyntaxKind.REMOTE_METHOD_CALL_ACTION);
+    public void init(CodeAnalysisContext ctx) {
+        ctx.addSyntaxNodeAnalysisTask(new RemoteMethodAnalyzer(), SyntaxKind.REMOTE_METHOD_CALL_ACTION);
+        ctx.addSyntaxNodeAnalysisTask(new InitializerParamAnalyzer(),
+                List.of(SyntaxKind.IMPLICIT_NEW_EXPRESSION, SyntaxKind.EXPLICIT_NEW_EXPRESSION));
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/MySQLCodeAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/MySQLCodeAnalyzer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.mysql.compiler;
+
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.projects.plugins.CodeAnalysisContext;
+import io.ballerina.projects.plugins.CodeAnalyzer;
+import io.ballerina.stdlib.mysql.compiler.analyzer.RemoteMethodAnalyzer;
+/**
+ * JDBC Code Analyzer.
+ */
+public class MySQLCodeAnalyzer extends CodeAnalyzer {
+
+    @Override
+    public void init(CodeAnalysisContext codeAnalysisContext) {
+        codeAnalysisContext.addSyntaxNodeAnalysisTask(new RemoteMethodAnalyzer(), SyntaxKind.REMOTE_METHOD_CALL_ACTION);
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/MySQLCodeAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/MySQLCodeAnalyzer.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.projects.plugins.CodeAnalysisContext;
 import io.ballerina.projects.plugins.CodeAnalyzer;
 import io.ballerina.stdlib.mysql.compiler.analyzer.InitializerParamAnalyzer;
+import io.ballerina.stdlib.mysql.compiler.analyzer.RecordAnalyzer;
 import io.ballerina.stdlib.mysql.compiler.analyzer.RemoteMethodAnalyzer;
 
 import java.util.List;
@@ -36,5 +37,7 @@ public class MySQLCodeAnalyzer extends CodeAnalyzer {
         ctx.addSyntaxNodeAnalysisTask(new RemoteMethodAnalyzer(), SyntaxKind.REMOTE_METHOD_CALL_ACTION);
         ctx.addSyntaxNodeAnalysisTask(new InitializerParamAnalyzer(),
                 List.of(SyntaxKind.IMPLICIT_NEW_EXPRESSION, SyntaxKind.EXPLICIT_NEW_EXPRESSION));
+        ctx.addSyntaxNodeAnalysisTask(new RecordAnalyzer(),
+                List.of(SyntaxKind.LOCAL_VAR_DECL, SyntaxKind.MODULE_VAR_DECL));
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/MySQLCompilerPlugin.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/MySQLCompilerPlugin.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.mysql.compiler;
+
+import io.ballerina.projects.plugins.CompilerPlugin;
+import io.ballerina.projects.plugins.CompilerPluginContext;
+
+/**
+ * Compiler plugin for JDBC client.
+ */
+public class MySQLCompilerPlugin extends CompilerPlugin {
+    @Override
+    public void init(CompilerPluginContext compilerPluginContext) {
+        compilerPluginContext.addCodeAnalyzer(new MySQLCodeAnalyzer());
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/MySQLDiagnosticsCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/MySQLDiagnosticsCode.java
@@ -33,8 +33,10 @@ public enum MySQLDiagnosticsCode {
     SQL_102("SQL_102", "invalid value: expected value is greater than zero", ERROR),
     SQL_103("SQL_103", "invalid value: expected value is greater than or equal to 30", ERROR),
 
-    MYSQL_101("MYSQL_101", "parameter 'rowType' should be explicitly passed when the return data is ignored", HINT),
-    MYSQL_102("MYSQL_102", "parameter 'returnType' should be explicitly passed when the return data is ignored", HINT);
+    MYSQL_101("MYSQL_101", "invalid value: expected value is greater than or equal to zero", ERROR),
+
+    MYSQL_901("MYSQL_901", "parameter 'rowType' should be explicitly passed when the return data is ignored", HINT),
+    MYSQL_902("MYSQL_902", "parameter 'returnType' should be explicitly passed when the return data is ignored", HINT);
 
     private final String code;
     private final String message;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/MySQLDiagnosticsCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/MySQLDiagnosticsCode.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.mysql.compiler;
+
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+
+import static io.ballerina.tools.diagnostics.DiagnosticSeverity.HINT;
+
+/**
+ * Enum class to hold JDBC module diagnostic codes.
+ */
+public enum MySQLDiagnosticsCode {
+    MYSQL_101("MYSQL_101", "parameter 'rowType' should be explicitly passed when the return data is ignored", HINT),
+    MYSQL_102("MYSQL_102", "parameter 'returnType' should be explicitly passed when the return data is ignored", HINT);
+
+    private final String code;
+    private final String message;
+    private final DiagnosticSeverity severity;
+
+    MySQLDiagnosticsCode(String code, String message, DiagnosticSeverity severity) {
+        this.code = code;
+        this.message = message;
+        this.severity = severity;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public DiagnosticSeverity getSeverity() {
+        return severity;
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/MySQLDiagnosticsCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/MySQLDiagnosticsCode.java
@@ -19,12 +19,20 @@ package io.ballerina.stdlib.mysql.compiler;
 
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 
+import static io.ballerina.tools.diagnostics.DiagnosticSeverity.ERROR;
 import static io.ballerina.tools.diagnostics.DiagnosticSeverity.HINT;
 
 /**
  * Enum class to hold JDBC module diagnostic codes.
  */
 public enum MySQLDiagnosticsCode {
+
+    //SQL ConnectionPool Validations at init
+    // todo See if this can be taken from the dependency.
+    SQL_101("SQL_101", "invalid value: expected value is greater than one", ERROR),
+    SQL_102("SQL_102", "invalid value: expected value is greater than zero", ERROR),
+    SQL_103("SQL_103", "invalid value: expected value is greater than or equal to 30", ERROR),
+
     MYSQL_101("MYSQL_101", "parameter 'rowType' should be explicitly passed when the return data is ignored", HINT),
     MYSQL_102("MYSQL_102", "parameter 'returnType' should be explicitly passed when the return data is ignored", HINT);
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/Utils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/Utils.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.mysql.compiler;
+
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+
+import java.util.Optional;
+
+/**
+ * Utils class.
+ */
+public class Utils {
+    public static boolean isJDBCClientObject(SyntaxNodeAnalysisContext ctx, ExpressionNode node) {
+        Optional<TypeSymbol> objectType = ctx.semanticModel().typeOf(node);
+        if (objectType.isEmpty()) {
+            return false;
+        }
+        if (objectType.get().typeKind() == TypeDescKind.UNION) {
+            return ((UnionTypeSymbol) objectType.get()).memberTypeDescriptors().stream()
+                    .filter(typeDescriptor -> typeDescriptor instanceof TypeReferenceTypeSymbol)
+                    .map(typeReferenceTypeSymbol -> (TypeReferenceTypeSymbol) typeReferenceTypeSymbol)
+                    .anyMatch(Utils::isJDBCClientObject);
+        }
+        if (objectType.get() instanceof TypeReferenceTypeSymbol) {
+            return isJDBCClientObject(((TypeReferenceTypeSymbol) objectType.get()));
+        }
+        return false;
+    }
+
+    public static boolean isJDBCClientObject(TypeReferenceTypeSymbol typeReference) {
+        Optional<ModuleSymbol> optionalModuleSymbol = typeReference.getModule();
+        if (optionalModuleSymbol.isEmpty()) {
+            return false;
+        }
+        ModuleSymbol module = optionalModuleSymbol.get();
+        if (!(module.id().orgName().equals(Constants.BALLERINAX) && module.id().moduleName().equals(Constants.MYSQL))) {
+            return false;
+        }
+        String objectName = typeReference.definition().getName().get();
+        return objectName.equals(Constants.Client.CLIENT);
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/Utils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/Utils.java
@@ -22,10 +22,22 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.syntax.tree.BasicLiteralNode;
 import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.compiler.syntax.tree.MappingConstructorExpressionNode;
+import io.ballerina.compiler.syntax.tree.MappingFieldNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
+import io.ballerina.compiler.syntax.tree.SpecificFieldNode;
+import io.ballerina.compiler.syntax.tree.UnaryExpressionNode;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.tools.diagnostics.DiagnosticFactory;
+import io.ballerina.tools.diagnostics.DiagnosticInfo;
 
 import java.util.Optional;
+
+import static io.ballerina.stdlib.mysql.compiler.Constants.UNNECESSARY_CHARS_REGEX;
+import static io.ballerina.stdlib.mysql.compiler.MySQLDiagnosticsCode.MYSQL_101;
 
 /**
  * Utils class.
@@ -59,5 +71,66 @@ public class Utils {
         }
         String objectName = typeReference.definition().getName().get();
         return objectName.equals(Constants.Client.CLIENT);
+    }
+
+    public static void validateOptions(SyntaxNodeAnalysisContext ctx, MappingConstructorExpressionNode options) {
+        SeparatedNodeList<MappingFieldNode> fields = options.fields();
+        for (MappingFieldNode field : fields) {
+            String name = ((SpecificFieldNode) field).fieldName().toString()
+                    .trim().replaceAll(UNNECESSARY_CHARS_REGEX, "");
+            ExpressionNode valueNode = ((SpecificFieldNode) field).valueExpr().get();
+            switch (name) {
+                case Constants.Options.CONNECTION_TIMEOUT:
+                case Constants.Options.SOCKET_TIMEOUT:
+                    float fieldVal = Float.parseFloat(getTerminalNodeValue(valueNode));
+                    if (fieldVal < 0) {
+                        DiagnosticInfo diagnosticInfo = new DiagnosticInfo(MYSQL_101.getCode(), MYSQL_101.getMessage(),
+                                MYSQL_101.getSeverity());
+                        ctx.reportDiagnostic(
+                                DiagnosticFactory.createDiagnostic(diagnosticInfo, valueNode.location()));
+                    }
+                    break;
+                case Constants.Options.FAILOVER:
+                    if (valueNode instanceof MappingConstructorExpressionNode) {
+                        validateFailOverConfig(ctx, (MappingConstructorExpressionNode) valueNode);
+                    }
+                    break;
+                default:
+                    // Can ignore all other fields
+                    continue;
+            }
+        }
+    }
+
+    public static void validateFailOverConfig(SyntaxNodeAnalysisContext ctx, MappingConstructorExpressionNode node) {
+        SeparatedNodeList<MappingFieldNode> failoverFields =
+                node.fields();
+        for (MappingFieldNode failoverField : failoverFields) {
+            String failoverFiled = ((SpecificFieldNode) failoverField).fieldName().toString()
+                    .trim().replaceAll(UNNECESSARY_CHARS_REGEX, "");
+            ExpressionNode failoverValue = ((SpecificFieldNode) failoverField).valueExpr().get();
+            if (failoverFiled.equals(Constants.FailOver.QUERY_BEFORE_RETRY) ||
+                    failoverFiled.equals(Constants.FailOver.TIME_BEFORE_RETRY)) {
+                int value = Integer.parseInt(getTerminalNodeValue(failoverValue));
+                if (value < 0) {
+                    DiagnosticInfo diagnosticInfo = new DiagnosticInfo(MYSQL_101.getCode(),
+                            MYSQL_101.getMessage(), MYSQL_101.getSeverity());
+                    ctx.reportDiagnostic(DiagnosticFactory.createDiagnostic(
+                            diagnosticInfo, failoverValue.location()));
+                }
+            }
+        }
+    }
+
+    public static String getTerminalNodeValue(Node valueNode) {
+        String value = "";
+        if (valueNode instanceof BasicLiteralNode) {
+            value = ((BasicLiteralNode) valueNode).literalToken().text();
+        } else if (valueNode instanceof UnaryExpressionNode) {
+            UnaryExpressionNode unaryExpressionNode = (UnaryExpressionNode) valueNode;
+            value = unaryExpressionNode.unaryOperator() +
+                    ((BasicLiteralNode) unaryExpressionNode.expression()).literalToken().text();
+        }
+        return value.replaceAll(UNNECESSARY_CHARS_REGEX, "");
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/analyzer/InitializerParamAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/analyzer/InitializerParamAnalyzer.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.mysql.compiler.analyzer;
+
+import io.ballerina.compiler.syntax.tree.BasicLiteralNode;
+import io.ballerina.compiler.syntax.tree.ExplicitNewExpressionNode;
+import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.compiler.syntax.tree.FunctionArgumentNode;
+import io.ballerina.compiler.syntax.tree.ImplicitNewExpressionNode;
+import io.ballerina.compiler.syntax.tree.MappingConstructorExpressionNode;
+import io.ballerina.compiler.syntax.tree.MappingFieldNode;
+import io.ballerina.compiler.syntax.tree.NamedArgumentNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.PositionalArgumentNode;
+import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
+import io.ballerina.compiler.syntax.tree.SpecificFieldNode;
+import io.ballerina.compiler.syntax.tree.UnaryExpressionNode;
+import io.ballerina.projects.plugins.AnalysisTask;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.mysql.compiler.Constants;
+import io.ballerina.stdlib.mysql.compiler.Utils;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticFactory;
+import io.ballerina.tools.diagnostics.DiagnosticInfo;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.ballerina.stdlib.mysql.compiler.Constants.CONNECTION_POOL_PARM_NAME;
+import static io.ballerina.stdlib.mysql.compiler.Constants.UNNECESSARY_CHARS_REGEX;
+import static io.ballerina.stdlib.mysql.compiler.MySQLDiagnosticsCode.SQL_101;
+import static io.ballerina.stdlib.mysql.compiler.MySQLDiagnosticsCode.SQL_102;
+import static io.ballerina.stdlib.mysql.compiler.MySQLDiagnosticsCode.SQL_103;
+
+/**
+ * Validate fields of sql:Connection pool fields.
+ */
+public class InitializerParamAnalyzer implements AnalysisTask<SyntaxNodeAnalysisContext> {
+    @Override
+    public void perform(SyntaxNodeAnalysisContext ctx) {
+        List<Diagnostic> diagnostics = ctx.semanticModel().diagnostics();
+        for (Diagnostic diagnostic : diagnostics) {
+            if (diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR) {
+                return;
+            }
+        }
+
+        if (!(Utils.isJDBCClientObject(ctx, ((ExpressionNode) ctx.node())))) {
+            return;
+        }
+
+        SeparatedNodeList<FunctionArgumentNode> arguments;
+        if (ctx.node() instanceof ImplicitNewExpressionNode) {
+            arguments = ((ImplicitNewExpressionNode) ctx.node()).parenthesizedArgList().get().arguments();
+        } else {
+            arguments = ((ExplicitNewExpressionNode) ctx.node()).parenthesizedArgList().arguments();
+        }
+
+        Optional<NamedArgumentNode> connectionPoolOptional = arguments.stream()
+                .filter(argNode -> argNode instanceof NamedArgumentNode)
+                .map(argNode -> (NamedArgumentNode) argNode)
+                .filter(arg -> arg.argumentName().name().text().equals(CONNECTION_POOL_PARM_NAME))
+                .findFirst();
+        ExpressionNode connectionPool;
+        if (connectionPoolOptional.isPresent()) {
+            connectionPool = connectionPoolOptional.get().expression();
+        } else if (arguments.size() == 7) {
+            // All params are present
+            connectionPool = ((PositionalArgumentNode) arguments.get(6)).expression();
+        } else {
+            return;
+        }
+        SeparatedNodeList<MappingFieldNode> fields =
+                ((MappingConstructorExpressionNode) connectionPool).fields();
+        for (MappingFieldNode field : fields) {
+            String name = ((SpecificFieldNode) field).fieldName().toString()
+                    .trim().replaceAll(UNNECESSARY_CHARS_REGEX, "");
+            ExpressionNode valueNode = ((SpecificFieldNode) field).valueExpr().get();
+            switch (name) {
+                case Constants.ConnectionPool.MAX_OPEN_CONNECTIONS:
+                    int maxOpenConnections = Integer.parseInt(getTerminalNodeValue(valueNode));
+                    if (maxOpenConnections < 1) {
+                        DiagnosticInfo diagnosticInfo = new DiagnosticInfo(SQL_101.getCode(), SQL_101.getMessage(),
+                                SQL_101.getSeverity());
+
+                        ctx.reportDiagnostic(
+                                DiagnosticFactory.createDiagnostic(diagnosticInfo, valueNode.location()));
+
+                    }
+                    break;
+                case Constants.ConnectionPool.MIN_IDLE_CONNECTIONS:
+                    int minIdleConnection = Integer.parseInt(getTerminalNodeValue(valueNode));
+                    if (minIdleConnection < 0) {
+                        DiagnosticInfo diagnosticInfo = new DiagnosticInfo(SQL_102.getCode(), SQL_102.getMessage(),
+                                SQL_102.getSeverity());
+                        ctx.reportDiagnostic(
+                                DiagnosticFactory.createDiagnostic(diagnosticInfo, valueNode.location()));
+
+                    }
+                    break;
+                case Constants.ConnectionPool.MAX_CONNECTION_LIFE_TIME:
+                    float maxConnectionTime = Float.parseFloat(getTerminalNodeValue(valueNode));
+                    if (maxConnectionTime < 30) {
+                        DiagnosticInfo diagnosticInfo = new DiagnosticInfo(SQL_103.getCode(), SQL_103.getMessage(),
+                                SQL_103.getSeverity());
+                        ctx.reportDiagnostic(
+                                DiagnosticFactory.createDiagnostic(diagnosticInfo, valueNode.location()));
+
+                    }
+                    break;
+                default:
+                    // Can ignore all other fields
+                    continue;
+            }
+        }
+    }
+
+    private String getTerminalNodeValue(Node valueNode) {
+        String value;
+        if (valueNode instanceof BasicLiteralNode) {
+            value = ((BasicLiteralNode) valueNode).literalToken().text();
+        } else {
+            UnaryExpressionNode unaryExpressionNode = (UnaryExpressionNode) valueNode;
+            value = unaryExpressionNode.unaryOperator() +
+                    ((BasicLiteralNode) unaryExpressionNode.expression()).literalToken().text();
+        }
+        return value.replaceAll(UNNECESSARY_CHARS_REGEX, "");
+    }
+
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/analyzer/RecordAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/analyzer/RecordAnalyzer.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.mysql.compiler.analyzer;
+
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.api.symbols.VariableSymbol;
+import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.compiler.syntax.tree.MappingConstructorExpressionNode;
+import io.ballerina.compiler.syntax.tree.ModuleVariableDeclarationNode;
+import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
+import io.ballerina.projects.plugins.AnalysisTask;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.mysql.compiler.Constants;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.ballerina.stdlib.mysql.compiler.Constants.BALLERINAX;
+import static io.ballerina.stdlib.mysql.compiler.Constants.MYSQL;
+import static io.ballerina.stdlib.mysql.compiler.Utils.validateFailOverConfig;
+import static io.ballerina.stdlib.mysql.compiler.Utils.validateOptions;
+
+/**
+ * Analyser for validation mysql:Options and mysql:FailoverConfig.
+ */
+public class RecordAnalyzer implements AnalysisTask<SyntaxNodeAnalysisContext> {
+    @Override
+    public void perform(SyntaxNodeAnalysisContext ctx) {
+        List<Diagnostic> diagnostics = ctx.semanticModel().diagnostics();
+        for (Diagnostic diagnostic : diagnostics) {
+            if (diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR) {
+                return;
+            }
+        }
+        Optional<Symbol> varSymOptional = ctx.semanticModel().symbol(ctx.node());
+        if (varSymOptional.isPresent()) {
+            TypeSymbol typeSymbol = ((VariableSymbol) varSymOptional.get()).typeDescriptor();
+
+            if (isMySQLRecord(typeSymbol, Constants.FailOver.NAME)) {
+                Optional<MappingConstructorExpressionNode> recordNode = getRecordNode(ctx);
+                if (recordNode.isEmpty()) {
+                    return;
+                }
+                validateFailOverConfig(ctx, recordNode.get());
+            } else if (isMySQLRecord(typeSymbol, Constants.Options.NAME)) {
+                Optional<MappingConstructorExpressionNode> recordNode = getRecordNode(ctx);
+                if (recordNode.isEmpty()) {
+                    return;
+                }
+                validateOptions(ctx, recordNode.get());
+            }
+        }
+    }
+
+    private Optional<MappingConstructorExpressionNode> getRecordNode(SyntaxNodeAnalysisContext ctx) {
+        // Initiated with a record
+        Optional<ExpressionNode> optionalInitializer;
+        if ((ctx.node() instanceof VariableDeclarationNode)) {
+            // Function level variables
+            optionalInitializer = ((VariableDeclarationNode) ctx.node()).initializer();
+        } else {
+            // Module level variables
+            optionalInitializer = ((ModuleVariableDeclarationNode) ctx.node()).initializer();
+        }
+        if (optionalInitializer.isEmpty()) {
+            return Optional.empty();
+        }
+        ExpressionNode initializer = optionalInitializer.get();
+        if (!(initializer instanceof MappingConstructorExpressionNode)) {
+            return Optional.empty();
+        }
+        return Optional.of((MappingConstructorExpressionNode) initializer);
+    }
+
+    private boolean isMySQLRecord(TypeSymbol type, String recordName) {
+        if (type.typeKind() == TypeDescKind.UNION) {
+            return ((UnionTypeSymbol) type).memberTypeDescriptors().stream()
+                    .filter(typeDescriptor -> typeDescriptor instanceof TypeReferenceTypeSymbol)
+                    .map(typeReferenceTypeSymbol -> (TypeReferenceTypeSymbol) typeReferenceTypeSymbol)
+                    .anyMatch(typeReferenceTypeSymbol -> isMySQLRecord(typeReferenceTypeSymbol, recordName));
+        }
+        if (type.typeKind() == TypeDescKind.TYPE_REFERENCE) {
+            return isMySQLRecord((TypeReferenceTypeSymbol) type, recordName);
+        }
+        return false;
+    }
+
+    private boolean isMySQLRecord(TypeReferenceTypeSymbol typeSymbol, String recordName) {
+        if (typeSymbol.typeDescriptor().typeKind() == TypeDescKind.RECORD) {
+            ModuleSymbol moduleSymbol = typeSymbol.getModule().get();
+            return MYSQL.equals(moduleSymbol.getName().get()) && BALLERINAX.equals(moduleSymbol.id().orgName())
+                    && typeSymbol.definition().getName().get().equals(recordName);
+        }
+        return false;
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/analyzer/RemoteMethodAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/analyzer/RemoteMethodAnalyzer.java
@@ -17,12 +17,27 @@
  */
 package io.ballerina.stdlib.mysql.compiler.analyzer;
 
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.compiler.syntax.tree.RemoteMethodCallActionNode;
 import io.ballerina.projects.plugins.AnalysisTask;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.mysql.compiler.Constants;
 import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticFactory;
+import io.ballerina.tools.diagnostics.DiagnosticInfo;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+import org.ballerinalang.util.diagnostic.DiagnosticErrorCode;
 
 import java.util.List;
+import java.util.Optional;
+
+import static io.ballerina.stdlib.mysql.compiler.MySQLDiagnosticsCode.MYSQL_101;
+import static io.ballerina.stdlib.mysql.compiler.MySQLDiagnosticsCode.MYSQL_102;
+import static org.ballerinalang.util.diagnostic.DiagnosticErrorCode.CANNOT_INFER_TYPE_FOR_PARAM;
 
 /**
  * MySQL Client remote call analyzer.
@@ -31,12 +46,60 @@ public class RemoteMethodAnalyzer implements AnalysisTask<SyntaxNodeAnalysisCont
 
     @Override
     public void perform(SyntaxNodeAnalysisContext ctx) {
+        RemoteMethodCallActionNode node = (RemoteMethodCallActionNode) ctx.node();
         List<Diagnostic> diagnostics = ctx.semanticModel().diagnostics();
-        for (Diagnostic diagnostic : diagnostics) {
-            if (diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR) {
-                return;
-            }
-        }
+        diagnostics.stream()
+                .filter(diagnostic -> diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR)
+                .filter(diagnostic ->
+                        diagnostic.diagnosticInfo().code().equals(CANNOT_INFER_TYPE_FOR_PARAM.diagnosticId()) ||
+                                diagnostic.diagnosticInfo().code().equals(
+                                      DiagnosticErrorCode.INCOMPATIBLE_TYPE_FOR_INFERRED_TYPEDESC_VALUE.diagnosticId()))
+                .filter(diagnostic -> diagnostic.location().lineRange().equals(node.location().lineRange()))
+                .forEach(diagnostic -> addHint(ctx, node));
     }
 
+    private void addHint(SyntaxNodeAnalysisContext ctx, RemoteMethodCallActionNode node) {
+        ExpressionNode methodExpression = node.expression();
+        Optional<TypeSymbol> methodExpReferenceType = ctx.semanticModel().typeOf(methodExpression);
+        if (methodExpReferenceType.isEmpty()) {
+            return;
+        }
+        TypeReferenceTypeSymbol methodExpTypeSymbol = (TypeReferenceTypeSymbol) methodExpReferenceType.get();
+        Optional<ModuleSymbol> optionalModuleSymbol = methodExpTypeSymbol.getModule();
+        if (optionalModuleSymbol.isEmpty()) {
+            return;
+        }
+        ModuleSymbol module = optionalModuleSymbol.get();
+        if (!(module.id().orgName().equals(Constants.BALLERINAX) && module.id().moduleName().equals(Constants.MYSQL))) {
+            return;
+        }
+        String objectName = ((TypeReferenceTypeSymbol) methodExpReferenceType.get()).definition().getName().get();
+        if (!objectName.equals(Constants.Client.CLIENT)) {
+            return;
+        }
+
+        Optional<Symbol> methodSymbol = ctx.semanticModel().symbol(node.methodName());
+        if (methodSymbol.isEmpty()) {
+            return;
+        }
+        Optional<String> methodName = methodSymbol.get().getName();
+        if (methodName.isEmpty()) {
+            return;
+        }
+
+        switch (methodName.get()) {
+            case Constants.Client.QUERY:
+                ctx.reportDiagnostic(DiagnosticFactory.createDiagnostic(
+                        new DiagnosticInfo(MYSQL_101.getCode(), MYSQL_101.getMessage(), MYSQL_101.getSeverity()),
+                        node.location()));
+                break;
+            case Constants.Client.QUERY_ROW:
+                ctx.reportDiagnostic(DiagnosticFactory.createDiagnostic(
+                        new DiagnosticInfo(MYSQL_102.getCode(), MYSQL_102.getMessage(), MYSQL_102.getSeverity()),
+                        node.location()));
+                break;
+            default:
+                return;
+        }
+    }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/analyzer/RemoteMethodAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/analyzer/RemoteMethodAnalyzer.java
@@ -17,15 +17,12 @@
  */
 package io.ballerina.stdlib.mysql.compiler.analyzer;
 
-import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
-import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
-import io.ballerina.compiler.api.symbols.TypeSymbol;
-import io.ballerina.compiler.syntax.tree.ExpressionNode;
 import io.ballerina.compiler.syntax.tree.RemoteMethodCallActionNode;
 import io.ballerina.projects.plugins.AnalysisTask;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 import io.ballerina.stdlib.mysql.compiler.Constants;
+import io.ballerina.stdlib.mysql.compiler.Utils;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.diagnostics.DiagnosticFactory;
 import io.ballerina.tools.diagnostics.DiagnosticInfo;
@@ -59,22 +56,7 @@ public class RemoteMethodAnalyzer implements AnalysisTask<SyntaxNodeAnalysisCont
     }
 
     private void addHint(SyntaxNodeAnalysisContext ctx, RemoteMethodCallActionNode node) {
-        ExpressionNode methodExpression = node.expression();
-        Optional<TypeSymbol> methodExpReferenceType = ctx.semanticModel().typeOf(methodExpression);
-        if (methodExpReferenceType.isEmpty()) {
-            return;
-        }
-        TypeReferenceTypeSymbol methodExpTypeSymbol = (TypeReferenceTypeSymbol) methodExpReferenceType.get();
-        Optional<ModuleSymbol> optionalModuleSymbol = methodExpTypeSymbol.getModule();
-        if (optionalModuleSymbol.isEmpty()) {
-            return;
-        }
-        ModuleSymbol module = optionalModuleSymbol.get();
-        if (!(module.id().orgName().equals(Constants.BALLERINAX) && module.id().moduleName().equals(Constants.MYSQL))) {
-            return;
-        }
-        String objectName = ((TypeReferenceTypeSymbol) methodExpReferenceType.get()).definition().getName().get();
-        if (!objectName.equals(Constants.Client.CLIENT)) {
+        if (!(Utils.isJDBCClientObject(ctx, node.expression()))) {
             return;
         }
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/analyzer/RemoteMethodAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/analyzer/RemoteMethodAnalyzer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.mysql.compiler.analyzer;
+
+import io.ballerina.projects.plugins.AnalysisTask;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+
+import java.util.List;
+
+/**
+ * MySQL Client remote call analyzer.
+ */
+public class RemoteMethodAnalyzer implements AnalysisTask<SyntaxNodeAnalysisContext> {
+
+    @Override
+    public void perform(SyntaxNodeAnalysisContext ctx) {
+        List<Diagnostic> diagnostics = ctx.semanticModel().diagnostics();
+        for (Diagnostic diagnostic : diagnostics) {
+            if (diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR) {
+                return;
+            }
+        }
+    }
+
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/analyzer/RemoteMethodAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mysql/compiler/analyzer/RemoteMethodAnalyzer.java
@@ -32,8 +32,8 @@ import org.ballerinalang.util.diagnostic.DiagnosticErrorCode;
 import java.util.List;
 import java.util.Optional;
 
-import static io.ballerina.stdlib.mysql.compiler.MySQLDiagnosticsCode.MYSQL_101;
-import static io.ballerina.stdlib.mysql.compiler.MySQLDiagnosticsCode.MYSQL_102;
+import static io.ballerina.stdlib.mysql.compiler.MySQLDiagnosticsCode.MYSQL_901;
+import static io.ballerina.stdlib.mysql.compiler.MySQLDiagnosticsCode.MYSQL_902;
 import static org.ballerinalang.util.diagnostic.DiagnosticErrorCode.CANNOT_INFER_TYPE_FOR_PARAM;
 
 /**
@@ -72,12 +72,12 @@ public class RemoteMethodAnalyzer implements AnalysisTask<SyntaxNodeAnalysisCont
         switch (methodName.get()) {
             case Constants.Client.QUERY:
                 ctx.reportDiagnostic(DiagnosticFactory.createDiagnostic(
-                        new DiagnosticInfo(MYSQL_101.getCode(), MYSQL_101.getMessage(), MYSQL_101.getSeverity()),
+                        new DiagnosticInfo(MYSQL_901.getCode(), MYSQL_901.getMessage(), MYSQL_901.getSeverity()),
                         node.location()));
                 break;
             case Constants.Client.QUERY_ROW:
                 ctx.reportDiagnostic(DiagnosticFactory.createDiagnostic(
-                        new DiagnosticInfo(MYSQL_102.getCode(), MYSQL_102.getMessage(), MYSQL_102.getSeverity()),
+                        new DiagnosticInfo(MYSQL_902.getCode(), MYSQL_902.getMessage(), MYSQL_902.getSeverity()),
                         node.location()));
                 break;
             default:

--- a/compiler-plugin/src/main/java/module-info.java
+++ b/compiler-plugin/src/main/java/module-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module io.ballerina.stdlib.mysql.compiler {
+    requires io.ballerina.lang;
+    requires io.ballerina.tools.api;
+    requires io.ballerina.parser;
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,7 @@ githubSpotbugsVersion=4.0.5
 githubJohnrengelmanShadowVersion=5.2.0
 underCouchDownloadVersion=4.0.4
 researchgateReleaseVersion=2.8.0
+testngVersion=7.4.0
 ballerinaGradlePluginVersion=0.14.1
 
 ballerinaLangVersion=2.0.0-beta.4-20211117-173300-4b039e51

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,11 +15,13 @@ rootProject.name = 'ballerina-mysql'
 
 include ':checkstyle'
 include ':mysql-native'
+include ':mysql-compiler-plugin'
 include ':mysql-ballerina'
 include ':mysql-compiler-plugin-tests'
 
 project(':checkstyle').projectDir = file("build-config${File.separator}checkstyle")
 project(':mysql-native').projectDir = file('native')
+project(':mysql-compiler-plugin').projectDir = file('compiler-plugin')
 project(':mysql-ballerina').projectDir = file('ballerina')
 project(':mysql-compiler-plugin-tests').projectDir = file('compiler-plugin-tests')
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,10 +16,12 @@ rootProject.name = 'ballerina-mysql'
 include ':checkstyle'
 include ':mysql-native'
 include ':mysql-ballerina'
+include ':mysql-compiler-plugin-tests'
 
 project(':checkstyle').projectDir = file("build-config${File.separator}checkstyle")
 project(':mysql-native').projectDir = file('native')
 project(':mysql-ballerina').projectDir = file('ballerina')
+project(':mysql-compiler-plugin-tests').projectDir = file('compiler-plugin-tests')
 
 gradleEnterprise {
     buildScan {


### PR DESCRIPTION
## Purpose
$subject

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/2279

## Examples

- Validating nonzero int/float values for mysql:Options, mysql:FailoverConfig in variable declaration and initialisation,
<img width="206" alt="Screenshot 2021-11-19 at 12 04 40" src="https://user-images.githubusercontent.com/27669465/142576686-9c88af34-2965-4ec2-9ad3-dbfe2224446a.png">
<img width="1186" alt="Screenshot 2021-11-19 at 12 03 04" src="https://user-images.githubusercontent.com/27669465/142576691-979aa54f-36eb-4b3e-8276-eecc048dc6ee.png">

- Add hints when query() and queryRow() methods cannot infer the return type description.

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests