### PR TITLE
Change the `extended library` word to `Ballerina library`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -55,5 +55,5 @@ stdlibHttpVersion=2.10.0
 # Level 06
 stdlibTransactionVersion=1.8.0
 
-# Ballerina extended library
+# Ballerina library
 stdlibMysqlDriverVersion=1.5.0


### PR DESCRIPTION
## Purpose
Change the `extended library` word to `Ballerina library`.

Fixes:

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility
