### PR TITLE
Upgrade bundled Debezium dependencies to 3.5.1.Final

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "mysql"
-version = "1.18.0"
+version = "1.19.0"
 authors = ["Ballerina"]
 keywords = ["Client", "Network", "SQL", "RDBMS", "MySQL", "Vendor/Oracle", "Area/Database", "Type/Connector", "Type/Trigger"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-mysql"
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "mysql-native"
-version = "1.18.0"
-path = "../native/build/libs/mysql-native-1.18.0.jar"
+version = "1.19.0"
+path = "../native/build/libs/mysql-native-1.19.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "mysql-compiler-plugin"
 class = "io.ballerina.stdlib.mysql.compiler.MySQLCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/mysql-compiler-plugin-1.18.0.jar"
+path = "../compiler-plugin/build/libs/mysql-compiler-plugin-1.19.0-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -44,7 +44,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.10.1"
+version = "2.12.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -254,7 +254,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.12.0"
+version = "2.14.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -422,7 +422,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "cdc"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "data.jsondata"},
@@ -438,7 +438,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "mysql"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "file"},
@@ -463,7 +463,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "mysql.cdc.driver"
-version = "1.0.2"
+version = "1.1.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerinax", name = "mysql.driver"}

--- a/ballerina/tests/resources/compose.yaml
+++ b/ballerina/tests/resources/compose.yaml
@@ -1,3 +1,4 @@
+name: ballerinax-mysql-tests
 services:
     mysql:
         image: mysql:8.0.40

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Upgrade CDC dependencies to the Debezium 3.5.1-compatible release line.
+
 ## [1.18.0] - 2026-04-03
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.ballerina.stdlib
-version=1.18.1-SNAPSHOT
+version=1.19.0-SNAPSHOT
 ballerinaLangVersion=2201.13.0
 
 checkstylePluginVersion=10.12.1
@@ -57,8 +57,8 @@ stdlibTransactionVersion=1.12.0
 
 # Ballerina library
 stdlibMysqlDriverVersion=1.8.0
-stdlibCdcVersion=1.3.2
-stdlibMySQLCdcDriverVersion=1.0.2
+stdlibCdcVersion=1.4.0
+stdlibMySQLCdcDriverVersion=1.1.0
 
 jacocoVersion=0.8.10
 balScanVersion=0.5.0


### PR DESCRIPTION
## Purpose

Upgrade the CDC dependencies consumed by this module (`ballerinax/cdc`, `ballerinax/mysql.cdc.driver`) to the Debezium 3.5.1.Final-compatible release line.

This module's own code is unchanged; only the dependency versions in `gradle.properties` are bumped. Verified locally against the bumped `cdc` (1.4.0) and `mysql.cdc.driver` (1.1.0) via `bal push --repository=local` — full `./gradlew build` passes (205/205 tests, including `testCdcListenerEvents`, `testDetachAfterStart`, `testAttachAfterStart`).

Also fixed a docker-compose project-name collision (`ballerina/tests/resources/compose.yaml` now sets an explicit `name:`) so this module's test containers don't collide with other CDC connector repos' test containers when run back-to-back on the same machine.

**Note:** this PR depends on [ballerinax/cdc#42](https://github.com/ballerina-platform/module-ballerinax-cdc/pull/42) and [ballerinax/mysql.cdc.driver#10](https://github.com/ballerina-platform/module-ballerinax-mysql.cdc.driver/pull/10) being merged and released first — until then, `stdlibCdcVersion`/`stdlibMySQLCdcDriverVersion` in `gradle.properties` won't resolve for anyone building from a fresh checkout, since there are intentionally no local/override pins masking that.

## Checklist

- [x] Read the [contributing guidelines](https://github.com/ballerina-platform/ballerina-standard-library/blob/main/docs/contributing-guidelines.md)
- [x] Updated the [change log](changelog.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Upgrade the MySQL module to version `1.19.0`.
- Update CDC dependencies to releases compatible with Debezium `3.5.1.Final`.
- Set an explicit Docker Compose project name to prevent test-container conflicts.
- Update the changelog and package dependency references.
- The dependency updates require the corresponding `ballerinax/cdc` and `ballerinax/mysql.cdc.driver` releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->